### PR TITLE
Set connectCompleter error on error at socket connect

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -61,6 +61,7 @@ class Client {
 
   ///server info
   Info get info => _info;
+
   ///connection status
   Healthcheck get healthcheck => _healthcheck;
 
@@ -127,6 +128,8 @@ class Client {
           return;
         } catch (err) {
           close();
+          // Set error into Completer
+          _connectCompleter.completeError(err);
         }
       }
     }


### PR DESCRIPTION
In current code, if hostname is wrong, **socket.connect** throw exception, but await for global client.connect connect will be in infinite loop.
Fix is with add error setting at exception caught into _connectCompleter. After that global await will received Future object with error.

Problem found on flutter app