### PR TITLE
Adding support for message headers that contain ':'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ test/go.sum
 build/
 doc/api/
 *.pem
+*.iml
+*.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ doc/api/
 *.pem
 *.iml
 *.idea/
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+* fix a bug that does not correctly parse headers containing the ':' character
+
 ## 0.6.1
 
 * fix nkeys decode issue

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -20,7 +20,7 @@ enum _ReceiveState {
 
 ///status of the nats client
 enum Status {
-  /// discontected or not connected
+  /// disconnected or not connected
   disconnected,
 
   /// tlsHandshake
@@ -32,7 +32,7 @@ enum Status {
   ///connected to server ready
   connected,
 
-  ///alread close by close or server
+  ///already close by close or server
   closed,
 
   ///automatic reconnection to server
@@ -143,7 +143,7 @@ class Client {
     }
   }
 
-  ///NATS Client Constructure
+  ///NATS Client Constructor
   Client() {
     _steamHandle();
   }

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -23,13 +23,13 @@ class Header {
     return this;
   }
 
-  /// get valure from key
+  /// get value from key
   /// return null if notfound
   String? get(String key) {
     return headers![key];
   }
 
-  /// constructure from bytes
+  /// construct from bytes
   static Header fromBytes(Uint8List b) {
     var str = utf8.decode(b);
     Map<String, String> m = {};
@@ -47,7 +47,7 @@ class Header {
     return Header(headers: m, version: version);
   }
 
-  /// conver to bytes
+  /// convert to bytes
   Uint8List toBytes() {
     var str = '${this.version}\r\n';
 
@@ -86,21 +86,21 @@ class Message<T> {
     return jsonDecoder!(string);
   }
 
-  ///constructure
+  ///constructor
   Message(this.subject, this.sid, this.byte, this._client,
       {this.replyTo, this.jsonDecoder, this.header});
 
   ///payload in string
   String get string => utf8.decode(byte);
 
-  ///Repond to message
+  ///Respond to message
   bool respond(Uint8List data) {
     if (replyTo == null || replyTo == '') return false;
     _client.pub(replyTo, data);
     return true;
   }
 
-  ///Repond to string message
+  ///Respond to string message
   bool respondString(String str) {
     return respond(utf8.encode(str) as Uint8List);
   }

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -12,7 +12,7 @@ class Header {
   /// headers key value
   Map<String, String>? headers;
 
-  /// constructure
+  /// constructor
   Header({this.headers, this.version = 'NATS/1.0'}) {
     this.headers ??= {};
   }
@@ -37,11 +37,18 @@ class Header {
     var version = strList[0];
     strList.removeAt(0);
     for (var h in strList) {
-      var kvStr = h.split(':');
-      if (kvStr.length != 2) {
+      /// values of headers can contain ':' so find the first index for the
+      /// correct split index
+      var splitIndex = h.indexOf(':');
+
+      /// if the index is <= to 0 it means there was either no ':' or its the
+      /// first character. In either case its not a valid header to split.
+      if (splitIndex <= 0) {
         continue;
       }
-      m[kvStr[0]] = kvStr[1];
+      var key = h.substring(0, splitIndex);
+      var value = h.substring(splitIndex + 1);
+      m[key] = value;
     }
 
     return Header(headers: m, version: version);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/chartchuo
 repository: https://github.com/chartchuo/dart-nats
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 # dependencies:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: dart_nats
 description: A Dart client for the NATS messaging system. Design to use with Dart and flutter.
-version: 0.6.1
+version: 0.6.2
 homepage: https://github.com/chartchuo
 repository: https://github.com/chartchuo/dart-nats
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.15.0 <4.0.0'
 
 # dependencies:
 

--- a/test/message_data_test.dart
+++ b/test/message_data_test.dart
@@ -36,7 +36,7 @@ void main() {
       await service.close();
       expect(receive.string, equals('respond'));
     });
-    test('resquest', () async {
+    test('request', () async {
       var server = Client();
       await server.connect(Uri.parse('ws://localhost:8080'));
       var service = server.sub('service');

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -76,11 +76,13 @@ void main() {
       header.add('key1', 'value1');
       header.add('key2', 'value2');
       header.add('key3', 'value3');
+      header.add('key4', 'value:with:colon');
       client.pub('subject1', Uint8List.fromList(txt.codeUnits), header: header);
       var msg = await sub.stream.first;
       await client.close();
       expect(String.fromCharCodes(msg.byte), equals(txt));
       expect(msg.header?.get('key1'), equals('value1'));
+      expect(msg.header?.get('key4'), equals('value:with:colon'));
       expect(msg.header?.toBytes(), equals(header.toBytes()));
     });
   });

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -36,7 +36,7 @@ void main() {
       await service.close();
       expect(receive.string, equals('respond'));
     });
-    test('resquest', () async {
+    test('request', () async {
       var server = Client();
       await server.connect(Uri.parse('ws://localhost:8080'));
       var service = server.sub('service');

--- a/test/readme.md
+++ b/test/readme.md
@@ -3,3 +3,5 @@ start nats servers before test
 cd dart-nats-docker
 docker-compose up
 ```
+
+tests should be run with 1 thread to avoid multiple listeners to the same subjects

--- a/test/request_test.dart
+++ b/test/request_test.dart
@@ -37,7 +37,7 @@ void main() {
       await server.close();
       expect(receive.string, equals('respond'));
     });
-    test('resquest', () async {
+    test('request', () async {
       var server = Client();
       await server.connect(Uri.parse('ws://localhost:8080'));
       var service = server.sub('service');
@@ -72,7 +72,7 @@ void main() {
       await server.close();
       expect(receive.string, equals('respond'));
     });
-    test('resquest with timeout', () async {
+    test('request with timeout', () async {
       var server = Client();
       await server.connect(Uri.parse('ws://localhost:8080'));
       var service = server.sub('service');
@@ -91,7 +91,7 @@ void main() {
       await server.close();
       expect(receive.string, equals('respond'));
     });
-    test('resquest with timeout exception', () async {
+    test('request with timeout exception', () async {
       var server = Client();
       await server.connect(Uri.parse('ws://localhost:8080'));
       var service = server.sub('service');

--- a/test/structure_test.dart
+++ b/test/structure_test.dart
@@ -74,7 +74,7 @@ void main() {
         throw Exception('missing data type');
       }
     });
-    test('resquest', () async {
+    test('request', () async {
       var server = Client();
       await server.connect(Uri.parse('nats://localhost:4222'));
       server.registerJsonDecoder<Student>(json2Student);
@@ -93,7 +93,7 @@ void main() {
       await server.close();
       expect(s1.score, equals(s2.score));
     });
-    test('resquest register jsonDecoder', () async {
+    test('request register jsonDecoder', () async {
       var server = Client();
       server.registerJsonDecoder<Student>(json2Student);
       await server.connect(Uri.parse('nats://localhost:4222'));


### PR DESCRIPTION
The existing code throws away headers containing ':'

This change allows those headers to be correctly parsed. 