### PR TITLE
Fix missing headers in request response

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -72,6 +72,11 @@ class Client {
   late Completer _pingCompleter;
   late Completer _connectCompleter;
 
+  /// Error handler for websocket errors
+  Function(dynamic) wsErrorHandler = (e) {
+    throw NatsException('listen ws error: $e');
+  };
+
   var _status = Status.disconnected;
 
   /// true if connected
@@ -300,7 +305,7 @@ class Client {
             _setStatus(Status.disconnected);
           }, onError: (e) {
             close();
-            throw NatsException('listen ws error: $e');
+            wsErrorHandler(e);
           });
           return true;
         case 'nats':

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -735,6 +735,7 @@ class Client {
       throw NatsException('inbox prefix can not change when connection in use');
     }
     _inboxPrefix = i;
+    _inboxSubPrefix = i;
   }
 
   /// set Inbox prefix default '_INBOX'

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -735,7 +735,7 @@ class Client {
       throw NatsException('inbox prefix can not change when connection in use');
     }
     _inboxPrefix = i;
-    _inboxSubPrefix = i;
+    _inboxSubPrefix = null;
   }
 
   /// set Inbox prefix default '_INBOX'

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -15,7 +15,6 @@ import 'subscription.dart';
 enum _ReceiveState {
   idle, //op=msg -> msg
   msg, //newline -> idle
-
 }
 
 ///status of the nats client
@@ -792,8 +791,14 @@ class Client {
     } finally {
       _mutex.release();
     }
-    var msg = Message<T>(resp.subject, resp.sid, resp.byte, this,
-        jsonDecoder: jsonDecoder);
+    var msg = Message<T>(
+      resp.subject,
+      resp.sid,
+      resp.byte,
+      this,
+      header: resp.header,
+      jsonDecoder: jsonDecoder,
+    );
     return msg;
   }
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -845,7 +845,9 @@ class Client {
     _secureSocket = null;
     await _tcpSocket?.close();
     _tcpSocket = null;
-
+    await _inboxSub?.close();
+    _inboxSub = null;
+    _inboxSubPrefix = null;
     _buffer = [];
     _clientStatus = _ClientStatus.closed;
   }


### PR DESCRIPTION
In the original code, the `msg` object returned from the request response does not contain the headers from the `resp` object.
```
var msg = Message<T>(resp.subject, resp.sid, resp.byte, this,
        jsonDecoder: jsonDecoder);
```
This causes problems especially when dealing with nats microservices since the status code and error is contained in the headers as such:
```
Nats-Service-Error: <error message>
Nats-Service-Error-Code: 404
```
A simple fix as such will solve the problem, although it might make more sense to add throw some errors for this, but I think this can be subject for another wrapper class for nats microservices.
```
var msg = Message<T>(
      resp.subject,
      resp.sid,
      resp.byte,
      this,
      header: resp.header,
      jsonDecoder: jsonDecoder,
    );
```

Fixes #28 