### PR TITLE
Update client.dart

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -710,6 +710,9 @@ class Client {
   }
 
   void _add(String str) {
+     if (status == Status.closed || status == Status.disconnected) {
+      return;
+     }
     if (_wsChannel != null) {
       // if (_wsChannel?.closeCode == null) return;
       _wsChannel?.sink.add(utf8.encode(str + '\r\n'));


### PR DESCRIPTION
Issue resolved when app is in background


======== Exception caught by services library ====================================================== The following StateError was thrown during a platform message callback: Bad state: StreamSink is closed

When the exception was thrown, this was the stack: 
#0      _StreamSinkImpl.add (dart:_http/http_impl.dart:918:7)
#1      _WebSocketImpl.add (dart:_http/websocket_impl.dart:1222:11)
#2      DelegatingStreamSink.add (package:async/src/delegate/stream_sink.dart:35:11)
#3      _CompleterSink.add (package:web_socket_channel/src/sink_completer.dart:88:25)
#4      Client._add (package:dart_nats/src/client.dart:720:24)
#5      Client._unSub (package:dart_nats/src/client.dart:708:7)
#6      Client.unSub (package:dart_nats/src/client.dart:691:5)
#7      Subscription.unSub (package:dart_nats/src/subscription.dart:33:13)