### PR TITLE
fix: AccountInfo.fromJson silently zeroes usage for single-tier accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fix `JetStream.accountInfo()` returning an all-zero `Tier` (memory/storage/streams/consumers all 0) for single-tier (non-multi-tenant) accounts — the common case. `AccountInfo.fromJson` was reading usage/limits from a nested `tier` key that a real server's `$JS.API.INFO` response never sends; those fields are at the top level. `Tier.fromJson` now also parses `memory`/`storage`/etc as `num` rather than `int`, since an unset `reserved_storage` limit can arrive as a uint64 `-1` sentinel that round-trips through JSON as a double too large for a direct `int` cast.
+
 ## 1.1.1
 
 * Fix defect #42: Ensure `newInbox` always appends a dot suffix (`.`) to `inboxPrefix` to conform to hierarchical NATS subject structures (`_INBOX.>` gateway callout authorization policy).

--- a/lib/src/jetstream.dart
+++ b/lib/src/jetstream.dart
@@ -1308,12 +1308,16 @@ class Tier {
   /// Factory from JSON map
   factory Tier.fromJson(Map<String, dynamic> json) {
     return Tier(
-      memory: json['memory'] as int? ?? 0,
-      storage: json['storage'] as int? ?? 0,
-      reservedMemory: json['reserved_memory'] as int? ?? 0,
-      reservedStorage: json['reserved_storage'] as int? ?? 0,
-      streams: json['streams'] as int? ?? 0,
-      consumers: json['consumers'] as int? ?? 0,
+      // Read as `num` rather than `int`: a server represents an unset
+      // reserved limit as a uint64 `-1` ("no limit") sentinel, which after
+      // JSON round-tripping through a double can arrive as e.g.
+      // `18446744073709552000.0` — a strict `as int?` cast throws on that.
+      memory: (json['memory'] as num?)?.toInt() ?? 0,
+      storage: (json['storage'] as num?)?.toInt() ?? 0,
+      reservedMemory: (json['reserved_memory'] as num?)?.toInt() ?? 0,
+      reservedStorage: (json['reserved_storage'] as num?)?.toInt() ?? 0,
+      streams: (json['streams'] as num?)?.toInt() ?? 0,
+      consumers: (json['consumers'] as num?)?.toInt() ?? 0,
     );
   }
 }
@@ -1384,7 +1388,15 @@ class AccountInfo {
     return AccountInfo(
       domain: json['domain'] as String? ?? '',
       api: APIStats.fromJson(json['api'] as Map<String, dynamic>? ?? {}),
-      tier: Tier.fromJson(json['tier'] as Map<String, dynamic>? ?? {}),
+      // The `$JS.API.INFO` response has no nested `tier` key — a server puts
+      // an account's own usage/limits (`memory`, `storage`, `streams`,
+      // `consumers`, `reserved_memory`, `reserved_storage`) at the top
+      // level, so `Tier.fromJson(json['tier'])` was always parsing an empty
+      // map and silently returning an all-zero `Tier`. Verified against a
+      // live server: `Tier.fromJson(json)` reads the real fields directly,
+      // and stays correct for multi-tier accounts too, since `json` there
+      // still carries the account-wide aggregate alongside `tiers`.
+      tier: Tier.fromJson(json),
       tiers: tiersMap,
     );
   }

--- a/test/jetstream_account_info_parsing_test.dart
+++ b/test/jetstream_account_info_parsing_test.dart
@@ -1,0 +1,77 @@
+import 'package:dart_nats/dart_nats.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AccountInfo.fromJson', () {
+    test('reads usage/limits from the top level of a single-tier response',
+        () {
+      // Captured verbatim from a live `nats:latest -js` server's
+      // `$JS.API.INFO` response after creating one stream. Single-tier
+      // (non-multi-tenant) accounts — the common case — have no `tier` key
+      // at all; the account's own usage/limits are top-level fields.
+      final json = {
+        'type': 'io.nats.jetstream.api.v1.account_info_response',
+        'memory': 0,
+        'storage': 0,
+        'reserved_memory': 0,
+        'reserved_storage': 18446744073709552000.0,
+        'streams': 1,
+        'consumers': 0,
+        'limits': {
+          'max_memory': -1,
+          'max_storage': -1,
+          'max_streams': -1,
+          'max_consumers': -1,
+        },
+        'api': {'level': 1, 'total': 8, 'errors': 0},
+      };
+
+      final info = AccountInfo.fromJson(json);
+
+      expect(info.tier.streams, 1);
+      expect(info.tier.consumers, 0);
+      expect(info.api.total, 8);
+      expect(info.api.level, 1);
+      expect(info.domain, '');
+      expect(info.tiers, isEmpty);
+    });
+
+    test('parses multi-tier accounts into the tiers map, keeping the '
+        'top-level fields as the account-wide aggregate', () {
+      final json = {
+        'streams': 2,
+        'api': {'total': 1},
+        'tiers': {
+          'R1': {'streams': 2, 'memory': 100},
+          'R3': {'streams': 0, 'memory': 0},
+        },
+      };
+
+      final info = AccountInfo.fromJson(json);
+
+      expect(info.tier.streams, 2);
+      expect(info.tiers.keys, containsAll(['R1', 'R3']));
+      expect(info.tiers['R1']!.streams, 2);
+      expect(info.tiers['R1']!.memory, 100);
+    });
+
+    test('defaults missing fields to zero/empty', () {
+      final info = AccountInfo.fromJson({});
+      expect(info.domain, '');
+      expect(info.tier.memory, 0);
+      expect(info.tier.streams, 0);
+      expect(info.api.total, 0);
+      expect(info.tiers, isEmpty);
+    });
+  });
+
+  group('Tier.fromJson', () {
+    test(
+        'does not throw on a huge double sentinel (a server\'s uint64 "-1 '
+        'unlimited" for reserved_storage, observed to round-trip through '
+        'JSON as 18446744073709552000.0)', () {
+      final tier = Tier.fromJson({'reserved_storage': 18446744073709552000.0});
+      expect(tier.reservedStorage, greaterThan(0));
+    });
+  });
+}

--- a/test/jetstream_test.dart
+++ b/test/jetstream_test.dart
@@ -448,9 +448,24 @@ void main() {
     });
 
     test('Account Info details', () async {
+      final streamName = 'account-info-test';
+      await js.createStream(StreamConfig(
+        name: streamName,
+        subjects: ['account-info-test.>'],
+        storage: 'memory',
+      ));
+
       final accInfo = await js.accountInfo();
-      expect(accInfo.tier.memory, isNotNull);
-      expect(accInfo.tier.consumers, isNotNull);
+      // Regression guard: `Tier.fromJson` used to always parse an empty map
+      // (the response has no nested `tier` key for a single-tier account),
+      // so every one of these silently came back as 0 regardless of real
+      // account state. Asserting `isNotNull` alone doesn't catch that, since
+      // 0 is not null — assert the stream we just created is actually
+      // reflected in the count.
+      expect(accInfo.tier.streams, greaterThanOrEqualTo(1));
+      expect(accInfo.api.total, greaterThan(0));
+
+      await js.deleteStream(streamName);
     });
   });
 }


### PR DESCRIPTION
`Tier.fromJson` was only ever called with `json['tier']`, but a real server's `$JS.API.INFO` response has no such nested key for the common case of a single-tier (non-multi-tenant) account — memory/storage/ streams/consumers/reserved_memory/reserved_storage are top-level fields instead. `accountInfo()` was therefore silently returning an all-zero `Tier` regardless of actual account state.

Fixes it by parsing `Tier.fromJson(json)` directly off the top-level response, which stays correct for multi-tier accounts too (the top level there is the account-wide aggregate, with the `tiers` map carrying the per-tier breakdown).

Also fixes a latent crash this uncovered: an unset `reserved_storage` limit arrives as a uint64 `-1` sentinel that, once the tier fields are actually being read, round-trips through JSON as a double too large for a strict `as int?` cast (observed against a live server as 18446744073709552000.0). `Tier.fromJson` now reads fields as `num?`.

Strengthens the existing "Account Info details" integration test (previously only asserted `isNotNull`, which 0 also satisfies) to create a stream first and assert the count reflects it, and adds a new pure-parsing unit test file covering the single-tier, multi-tier, and sentinel-value cases without needing a live server.