### PR TITLE
feat: add client-side service discovery (ADR-32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add client-side service discovery for the ADR-32 Microservices framework, complementing the recently-added `addService`/`MicroService`. `Client.discoverServices()`/`getServicesInfo()`/`getServicesStats()` fan a `$SRV.PING`/`INFO`/`STATS` request out to `$SRV.*` (optionally scoped to one service name, or one service+instance id) and collect every reply that arrives within a bounded window, since multiple instances can legitimately reply to a single discovery request (unlike `Client.request()`'s single-reply semantics). Adds `PingResponse`/`InfoResponse`/`EndpointInfo`/`StatsResponse`/`EndpointStatsInfo` to parse the standard `io.nats.micro.v1.*_response` payloads.
+
 ## 1.1.2
 
 * Fix `JetStream.accountInfo()` returning all-zero `Tier` for single-tier accounts by parsing usage fields from the top-level response instead of a nonexistent nested `tier` key. Also fix `Tier.fromJson` crash on uint64 sentinel values by reading fields as `num`. Thanks [nverbeek](https://github.com/nverbeek) for the contribution.

--- a/lib/src/micro.dart
+++ b/lib/src/micro.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 import 'client.dart';
 import 'message.dart';
 import 'subscription.dart';
@@ -221,5 +222,302 @@ extension ClientMicroServiceExtension on Client {
     final service = MicroService(this, config, id);
     await service.start();
     return service;
+  }
+}
+
+/// Reply to a `$SRV.PING` discovery request (`io.nats.micro.v1.ping_response`)
+class PingResponse {
+  /// Unique service instance ID that replied
+  final String id;
+
+  /// Service name
+  final String name;
+
+  /// Service version
+  final String version;
+
+  /// Service metadata
+  final Map<String, String> metadata;
+
+  /// Constructor for PingResponse
+  PingResponse({
+    required this.id,
+    required this.name,
+    required this.version,
+    this.metadata = const {},
+  });
+
+  /// Parse from a decoded JSON map
+  factory PingResponse.fromJson(Map<String, dynamic> json) {
+    return PingResponse(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      version: json['version'] as String,
+      metadata:
+          (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
+    );
+  }
+}
+
+/// Endpoint summary within an [InfoResponse]
+class EndpointInfo {
+  /// Name of the endpoint
+  final String name;
+
+  /// NATS subject the endpoint listens on
+  final String subject;
+
+  /// Endpoint metadata
+  final Map<String, String> metadata;
+
+  /// Constructor for EndpointInfo
+  EndpointInfo({
+    required this.name,
+    required this.subject,
+    this.metadata = const {},
+  });
+
+  /// Parse from a decoded JSON map
+  factory EndpointInfo.fromJson(Map<String, dynamic> json) {
+    return EndpointInfo(
+      name: json['name'] as String,
+      subject: json['subject'] as String,
+      metadata:
+          (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
+    );
+  }
+}
+
+/// Reply to a `$SRV.INFO` discovery request (`io.nats.micro.v1.info_response`)
+class InfoResponse {
+  /// Unique service instance ID that replied
+  final String id;
+
+  /// Service name
+  final String name;
+
+  /// Service version
+  final String version;
+
+  /// Service description
+  final String description;
+
+  /// Service metadata
+  final Map<String, String> metadata;
+
+  /// Endpoints exposed by this service instance
+  final List<EndpointInfo> endpoints;
+
+  /// Constructor for InfoResponse
+  InfoResponse({
+    required this.id,
+    required this.name,
+    required this.version,
+    this.description = '',
+    this.metadata = const {},
+    this.endpoints = const [],
+  });
+
+  /// Parse from a decoded JSON map
+  factory InfoResponse.fromJson(Map<String, dynamic> json) {
+    return InfoResponse(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      version: json['version'] as String,
+      description: json['description'] as String? ?? '',
+      metadata:
+          (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
+      endpoints: (json['endpoints'] as List? ?? const [])
+          .map((e) => EndpointInfo.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// Per-endpoint statistics within a [StatsResponse]
+class EndpointStatsInfo {
+  /// Name of the endpoint
+  final String name;
+
+  /// NATS subject the endpoint listens on
+  final String subject;
+
+  /// Total number of requests processed
+  final int numRequests;
+
+  /// Total number of errors encountered
+  final int numErrors;
+
+  /// Description of the last error, if any
+  final String lastError;
+
+  /// Total processing time elapsed, in nanoseconds
+  final int processingTimeNs;
+
+  /// Average processing time per request, in nanoseconds
+  final int averageProcessingTimeNs;
+
+  /// Constructor for EndpointStatsInfo
+  EndpointStatsInfo({
+    required this.name,
+    required this.subject,
+    this.numRequests = 0,
+    this.numErrors = 0,
+    this.lastError = '',
+    this.processingTimeNs = 0,
+    this.averageProcessingTimeNs = 0,
+  });
+
+  /// Parse from a decoded JSON map
+  factory EndpointStatsInfo.fromJson(Map<String, dynamic> json) {
+    return EndpointStatsInfo(
+      name: json['name'] as String,
+      subject: json['subject'] as String,
+      numRequests: (json['num_requests'] as num?)?.toInt() ?? 0,
+      numErrors: (json['num_errors'] as num?)?.toInt() ?? 0,
+      lastError: json['last_error'] as String? ?? '',
+      processingTimeNs: (json['processing_time'] as num?)?.toInt() ?? 0,
+      averageProcessingTimeNs:
+          (json['average_processing_time'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+/// Reply to a `$SRV.STATS` discovery request (`io.nats.micro.v1.stats_response`)
+class StatsResponse {
+  /// Unique service instance ID that replied
+  final String id;
+
+  /// Service name
+  final String name;
+
+  /// Service version
+  final String version;
+
+  /// When this service instance started
+  final DateTime started;
+
+  /// Per-endpoint statistics
+  final List<EndpointStatsInfo> endpoints;
+
+  /// Constructor for StatsResponse
+  StatsResponse({
+    required this.id,
+    required this.name,
+    required this.version,
+    required this.started,
+    this.endpoints = const [],
+  });
+
+  /// Parse from a decoded JSON map
+  factory StatsResponse.fromJson(Map<String, dynamic> json) {
+    final stats = json['stats'] as Map<String, dynamic>? ?? const {};
+    return StatsResponse(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      version: json['version'] as String,
+      started: DateTime.parse(json['started'] as String),
+      endpoints: (stats['endpoints'] as List? ?? const [])
+          .map((e) => EndpointStatsInfo.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// Extension on Client class adding Microservice discovery (ADR-32 client side).
+///
+/// Complements [ClientMicroServiceExtension.addService]: where that lets a
+/// client *host* a service, this lets a client *find* services already
+/// running on the account by fanning a request out to the same `$SRV.*`
+/// control subjects and collecting every reply that arrives within a
+/// bounded window (multiple instances can legitimately reply to one
+/// discovery request, so this is not a single-reply [Client.request]).
+extension ClientServiceDiscoveryExtension on Client {
+  Future<List<T>> _collectServiceReplies<T>(
+    String verb,
+    T Function(Map<String, dynamic>) fromJson, {
+    String? name,
+    String? id,
+    required Duration timeout,
+  }) async {
+    var subject = '\$SRV.$verb';
+    if (name != null) {
+      subject += '.$name';
+      if (id != null) {
+        subject += '.$id';
+      }
+    }
+
+    final replySubject = newInbox(inboxPrefix: inboxPrefix);
+    final replySub = sub<dynamic>(replySubject);
+    final results = <T>[];
+
+    final listener = replySub.stream.listen((msg) {
+      try {
+        results.add(fromJson(jsonDecode(msg.string) as Map<String, dynamic>));
+      } catch (_) {
+        // Ignore replies that don't conform to the expected shape rather
+        // than letting one misbehaving responder abort discovery for
+        // everyone else.
+      }
+    });
+
+    await pub(subject, Uint8List(0), replyTo: replySubject);
+    await Future<void>.delayed(timeout);
+
+    await listener.cancel();
+    unSub(replySub);
+
+    return results;
+  }
+
+  /// Discover running services by fanning out a `$SRV.PING` request and
+  /// collecting every reply that arrives within [timeout]. Pass [name] to
+  /// target one service (every instance of it replies), or both [name] and
+  /// [id] to target a single instance.
+  Future<List<PingResponse>> discoverServices({
+    String? name,
+    String? id,
+    Duration timeout = const Duration(milliseconds: 500),
+  }) {
+    return _collectServiceReplies(
+      'PING',
+      PingResponse.fromJson,
+      name: name,
+      id: id,
+      timeout: timeout,
+    );
+  }
+
+  /// Fetch `$SRV.INFO` (endpoints and subjects) for every running service,
+  /// or a single service/instance when [name]/[id] are given.
+  Future<List<InfoResponse>> getServicesInfo({
+    String? name,
+    String? id,
+    Duration timeout = const Duration(milliseconds: 500),
+  }) {
+    return _collectServiceReplies(
+      'INFO',
+      InfoResponse.fromJson,
+      name: name,
+      id: id,
+      timeout: timeout,
+    );
+  }
+
+  /// Fetch `$SRV.STATS` (request/error counts, latency) for every running
+  /// service, or a single service/instance when [name]/[id] are given.
+  Future<List<StatsResponse>> getServicesStats({
+    String? name,
+    String? id,
+    Duration timeout = const Duration(milliseconds: 500),
+  }) {
+    return _collectServiceReplies(
+      'STATS',
+      StatsResponse.fromJson,
+      name: name,
+      id: id,
+      timeout: timeout,
+    );
   }
 }

--- a/test/api_enhancements_test.dart
+++ b/test/api_enhancements_test.dart
@@ -569,5 +569,96 @@ SUACSSL3UAHUDXKFSNVUZRF5UHPMWZ6BFDTJ7M6USDXIEDNPPQYYYCU3VY
       await service.stop();
       await client.close();
     });
+
+    test('Service discovery: fan-in PING collects every running instance',
+        () async {
+      final client = Client();
+      await client.connect(Uri.parse('nats://localhost:4222'), retry: false);
+
+      final instance1 = Client();
+      await instance1.connect(Uri.parse('nats://localhost:4222'),
+          retry: false);
+      final instance2 = Client();
+      await instance2.connect(Uri.parse('nats://localhost:4222'),
+          retry: false);
+
+      final service1 = await instance1.addService(ServiceConfig(
+        name: 'discovery-fanout-service',
+        version: '1.0.0',
+      ));
+      final service2 = await instance2.addService(ServiceConfig(
+        name: 'discovery-fanout-service',
+        version: '1.0.0',
+      ));
+
+      // Bare $SRV.PING should be answered by both running instances.
+      final replies = await client.discoverServices(
+        timeout: const Duration(milliseconds: 800),
+      );
+      final ours =
+          replies.where((r) => r.name == 'discovery-fanout-service').toList();
+
+      expect(ours.length, equals(2));
+      expect(ours.map((r) => r.id).toSet().length, equals(2));
+      expect(ours.every((r) => r.version == '1.0.0'), isTrue);
+
+      // A name that nothing is registered under should collect nothing,
+      // and still resolve once the collection window elapses.
+      final none = await client.discoverServices(
+        name: 'no-such-service',
+        timeout: const Duration(milliseconds: 300),
+      );
+      expect(none, isEmpty);
+
+      await service1.stop();
+      await service2.stop();
+      await instance1.close();
+      await instance2.close();
+      await client.close();
+    });
+
+    test('Service discovery: targeted INFO and STATS for a named service',
+        () async {
+      final client = Client();
+      await client.connect(Uri.parse('nats://localhost:4222'), retry: false);
+
+      final service = await client.addService(ServiceConfig(
+        name: 'discovery-detail-service',
+        version: '2.1.0',
+        description: 'Discovery detail test service',
+        endpoints: [
+          Endpoint(
+            name: 'echo',
+            subject: 'discovery.echo',
+            handler: (msg) {
+              msg.respondString('echo-response');
+            },
+          ),
+        ],
+      ));
+
+      // Drive one request through the endpoint so STATS has something to report.
+      await client.requestString('discovery.echo', 'ping');
+
+      final infoReplies =
+          await client.getServicesInfo(name: 'discovery-detail-service');
+      expect(infoReplies.length, equals(1));
+      expect(infoReplies.single.description,
+          equals('Discovery detail test service'));
+      expect(infoReplies.single.endpoints.single.name, equals('echo'));
+      expect(
+          infoReplies.single.endpoints.single.subject, equals('discovery.echo'));
+
+      final statsReplies =
+          await client.getServicesStats(name: 'discovery-detail-service');
+      expect(statsReplies.length, equals(1));
+      final epStats = statsReplies.single.endpoints.single;
+      expect(epStats.name, equals('echo'));
+      expect(epStats.numRequests, equals(1));
+      expect(epStats.numErrors, equals(0));
+
+      await service.stop();
+      await client.close();
+    });
   });
 }


### PR DESCRIPTION
Complements the recently-added addService/MicroService hosting side with the other half of the Microservices framework: Client.discoverServices()/ getServicesInfo()/getServicesStats() fan a $SRV.PING/INFO/STATS request out to $SRV.* (optionally scoped to one service name, or one service+instance id) and collect every reply that arrives within a bounded window, since multiple instances can legitimately reply to a single discovery request (unlike Client.request()'s single-reply semantics).

Adds PingResponse/InfoResponse/EndpointInfo/StatsResponse/EndpointStatsInfo to parse the standard io.nats.micro.v1.*_response payloads produced by MicroService, so a discovering client interoperates with any ADR-32- conformant service, not just ones hosted by this library.