### PR TITLE
Fix/upstream bug batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* Fix `JetStream.listStreams()`/`listConsumers()` silently truncating at the server's page size (256 items) instead of paginating via `offset`/`total` — accounts with more streams/consumers than that lost visibility into everything past the first page, with no error or truncation flag.
+* Fix `Consumer.messages()`'s pull loop and `OrderedConsumer` swallowing every delivery failure into a silent retry loop instead of surfacing it through the stream's `addError`. For pull consumers specifically, a deleted server-side consumer never actually threw from `fetch()` — it silently timed out with an empty batch, indistinguishable from a merely idle consumer — so the loop now also confirms the consumer still exists whenever a batch comes back empty.
+* Fix `KeyValue.watch()`/`history()`/`keys()` leaking their ephemeral push consumer on every call — the `Consumer` returned by `createConsumer()` was discarded and never deleted once the caller cancelled or the call finished. `ConsumerConfig` also gains an `inactiveThreshold` field (serialized as `inactive_threshold`, same convention as `idleHeartbeat`) so ephemeral consumers can be given a server-side reap window as a safety net.
+* Add `Message.nakSync()`/`termSync()`/`inProgressSync()`, awaitable twins of the existing `ackSync()` for `nak()`/`term()`/`inProgress()`. The originals call `pub()` without awaiting its own `Future<bool>`, so a disconnected client still reports success even though the ack/nak/term never reached the server — prefer the `*Sync` variants when that needs to be known.
+
 ## 1.2.1
 
 * Update README.md with Microservices Framework (ADR-32) and Client Discovery documentation.

--- a/lib/src/jetstream.dart
+++ b/lib/src/jetstream.dart
@@ -1150,7 +1150,13 @@ class OrderedConsumer {
         // Wait until consumer resets or closes
         await completer.future;
       } catch (e) {
-        // Wait before retrying
+        // Surface the failure to listeners (e.g. createConsumer rejected the
+        // config -- a workqueue-retention stream requires explicit ack,
+        // for example) instead of retrying silently forever, then back off
+        // to avoid a tight loop.
+        if (_controller != null && !_controller!.isClosed) {
+          _controller!.addError(e);
+        }
         await Future.delayed(const Duration(seconds: 1));
       }
     }
@@ -1253,12 +1259,27 @@ class Consumer<T> {
         }
         try {
           final msgs = await fetch(batch: batch, timeout: timeout);
+          if (msgs.isEmpty) {
+            // An empty batch is the normal "nothing new yet" outcome, but
+            // it's also indistinguishable from a consumer that was deleted
+            // server-side: the pull request has no responder left to answer
+            // it, so it silently times out with no error and no status
+            // message either, exactly like a healthy idle consumer would.
+            // Disambiguate by confirming the consumer still exists whenever
+            // a batch comes back empty, so a deleted consumer is detected
+            // within one fetch cycle instead of polling forever with
+            // nothing ever surfaced.
+            await info(timeout: timeout);
+          }
           for (final msg in msgs) {
             if (!active || controller.isClosed) break;
             controller.add(msg);
           }
         } catch (e) {
-          // Avoid tight loop if fetch throws
+          // Surface the failure to listeners (e.g. the consumer was deleted
+          // server-side) instead of retrying silently forever, then back off
+          // to avoid a tight loop.
+          if (!controller.isClosed) controller.addError(e);
           await Future.delayed(const Duration(seconds: 1));
         }
       }

--- a/lib/src/jetstream.dart
+++ b/lib/src/jetstream.dart
@@ -175,6 +175,14 @@ class ConsumerConfig {
   /// Idle heartbeat duration
   final Duration? idleHeartbeat;
 
+  /// How long the server waits with no interest (no pull requests, no
+  /// connected push subscriber) before automatically deleting this
+  /// consumer. Chiefly useful as a safety net for ephemeral consumers: if
+  /// the owning client vanishes uncleanly (crash, network drop) without
+  /// ever calling `deleteConsumer`, the server reaps it on its own instead
+  /// of leaving it orphaned indefinitely.
+  final Duration? inactiveThreshold;
+
   /// Constructor for ConsumerConfig
   ConsumerConfig({
     this.durable,
@@ -185,6 +193,7 @@ class ConsumerConfig {
     this.optStartSeq,
     this.flowControl,
     this.idleHeartbeat,
+    this.inactiveThreshold,
   });
 
   /// Export configuration to JSON map
@@ -201,6 +210,10 @@ class ConsumerConfig {
     if (idleHeartbeat != null) {
       map['idle_heartbeat'] =
           idleHeartbeat!.inMicroseconds * 1000; // in nanoseconds
+    }
+    if (inactiveThreshold != null) {
+      map['inactive_threshold'] =
+          inactiveThreshold!.inMicroseconds * 1000; // in nanoseconds
     }
     return map;
   }

--- a/lib/src/jetstream.dart
+++ b/lib/src/jetstream.dart
@@ -594,20 +594,36 @@ class JetStream {
     return true;
   }
 
-  /// List all streams
+  /// List all streams visible to the account.
+  ///
+  /// Paginates through `\$JS.API.STREAM.LIST` as needed: nats-server caps
+  /// each response to a fixed page (256 items) regardless of how many
+  /// streams actually exist, reporting the true count in the same
+  /// response's `total` field. A single unpaginated request silently drops
+  /// everything past the first page on accounts with more streams than
+  /// that -- no error, no truncation flag.
   Future<List<StreamInfo>> listStreams(
       {Duration timeout = const Duration(seconds: 2)}) async {
     const subject = '\$JS.API.STREAM.LIST';
-    final response =
-        await client.request(subject, Uint8List.fromList([]), timeout: timeout);
-    final map = jsonDecode(response.string);
-    if (map['error'] != null) {
-      throw NatsException(map['error']['description'] as String);
+    final streams = <StreamInfo>[];
+    var offset = 0;
+    while (true) {
+      final payload = utf8.encode(jsonEncode({'offset': offset}));
+      final response = await client
+          .request(subject, Uint8List.fromList(payload), timeout: timeout);
+      final map = jsonDecode(response.string);
+      if (map['error'] != null) {
+        throw NatsException(map['error']['description'] as String);
+      }
+      final page = (map['streams'] as List? ?? [])
+          .map((item) => StreamInfo.fromJson(item as Map<String, dynamic>))
+          .toList();
+      streams.addAll(page);
+      final total = map['total'] as int? ?? streams.length;
+      offset += page.length;
+      if (page.isEmpty || offset >= total) break;
     }
-    final list = map['streams'] as List? ?? [];
-    return list
-        .map((item) => StreamInfo.fromJson(item as Map<String, dynamic>))
-        .toList();
+    return streams;
   }
 
   /// Find a stream name by a subject it covers
@@ -648,20 +664,31 @@ class JetStream {
     return consumerInfo(streamName, consumerName, timeout: timeout);
   }
 
-  /// List consumers on a stream
+  /// List consumers on a stream, paginating through
+  /// `\$JS.API.CONSUMER.LIST.<stream>` the same way [listStreams] does --
+  /// see its doc comment for why an unpaginated request isn't safe.
   Future<List<ConsumerInfo>> listConsumers(String streamName,
       {Duration timeout = const Duration(seconds: 2)}) async {
     final subject = '\$JS.API.CONSUMER.LIST.$streamName';
-    final response =
-        await client.request(subject, Uint8List.fromList([]), timeout: timeout);
-    final map = jsonDecode(response.string);
-    if (map['error'] != null) {
-      throw NatsException(map['error']['description'] as String);
+    final consumers = <ConsumerInfo>[];
+    var offset = 0;
+    while (true) {
+      final payload = utf8.encode(jsonEncode({'offset': offset}));
+      final response = await client
+          .request(subject, Uint8List.fromList(payload), timeout: timeout);
+      final map = jsonDecode(response.string);
+      if (map['error'] != null) {
+        throw NatsException(map['error']['description'] as String);
+      }
+      final page = (map['consumers'] as List? ?? [])
+          .map((item) => ConsumerInfo.fromJson(item as Map<String, dynamic>))
+          .toList();
+      consumers.addAll(page);
+      final total = map['total'] as int? ?? consumers.length;
+      offset += page.length;
+      if (page.isEmpty || offset >= total) break;
     }
-    final list = map['consumers'] as List? ?? [];
-    return list
-        .map((item) => ConsumerInfo.fromJson(item as Map<String, dynamic>))
-        .toList();
+    return consumers;
   }
 
   /// Create a consumer (durable or ephemeral) on a stream

--- a/lib/src/kv.dart
+++ b/lib/src/kv.dart
@@ -322,20 +322,37 @@ class KeyValue {
       filterSubject: '\$KV.$bucket.$key',
       deliverPolicy: includeHistory ? 'all' : 'last',
       ackPolicy: 'none',
+      // Safety net if `onCancel`'s own deleteConsumer below never runs
+      // (e.g. the client vanishes uncleanly instead of cancelling the
+      // stream) -- without this, an ephemeral consumer with no durable
+      // name and no inactivity threshold is never reaped by the server on
+      // its own and leaks indefinitely.
+      inactiveThreshold: const Duration(minutes: 5),
     );
 
+    Consumer<dynamic>? ephemeralConsumer;
     client
         .jetStream()
         .createConsumer(streamName, consumerConfig)
+        .then((consumer) => ephemeralConsumer = consumer)
         .catchError((dynamic err) {
       controller.addError(err);
       controller.close();
       throw err;
     });
 
-    controller.onCancel = () {
+    controller.onCancel = () async {
       streamSub.cancel();
       client.unSub(sub);
+      final consumer = ephemeralConsumer;
+      if (consumer != null) {
+        try {
+          await client.jetStream().deleteConsumer(streamName, consumer.name);
+        } catch (_) {
+          // Best-effort: the inactiveThreshold above still reaps it
+          // eventually if this fails (e.g. already disconnected).
+        }
+      }
     };
 
     return controller.stream;
@@ -387,17 +404,28 @@ class KeyValue {
       filterSubject: '\$KV.$bucket.>',
       deliverPolicy: 'all',
       ackPolicy: 'none',
+      // Safety net if cleanup()'s own deleteConsumer call below never runs.
+      inactiveThreshold: const Duration(minutes: 5),
     );
 
     final activeKeys = <String, bool>{}; // key -> is_active
     final completer = Completer<List<String>>();
     StreamSubscription? streamSub;
     Timer? timeoutTimer;
+    Consumer<dynamic>? ephemeralConsumer;
 
     void cleanup() {
       timeoutTimer?.cancel();
       streamSub?.cancel();
       client.unSub(sub);
+      final consumer = ephemeralConsumer;
+      if (consumer != null) {
+        ephemeralConsumer = null;
+        client
+            .jetStream()
+            .deleteConsumer(streamName, consumer.name)
+            .catchError((_) => false);
+      }
     }
 
     timeoutTimer = Timer(timeout, () {
@@ -459,7 +487,8 @@ class KeyValue {
     });
 
     try {
-      await client.jetStream().createConsumer(streamName, consumerConfig);
+      ephemeralConsumer =
+          await client.jetStream().createConsumer(streamName, consumerConfig);
     } catch (e) {
       cleanup();
       if (!completer.isCompleted) {
@@ -480,6 +509,7 @@ class KeyValue {
 
     StreamSubscription? streamSub;
     Timer? timeoutTimer;
+    Consumer<dynamic>? ephemeralConsumer;
 
     void cleanup() {
       timeoutTimer?.cancel();
@@ -487,6 +517,14 @@ class KeyValue {
       client.unSub(sub);
       if (!controller.isClosed) {
         controller.close();
+      }
+      final consumer = ephemeralConsumer;
+      if (consumer != null) {
+        ephemeralConsumer = null;
+        client
+            .jetStream()
+            .deleteConsumer(streamName, consumer.name)
+            .catchError((_) => false);
       }
     }
 
@@ -552,7 +590,11 @@ class KeyValue {
               filterSubject: '\$KV.$bucket.$key',
               deliverPolicy: 'all',
               ackPolicy: 'none',
+              // Safety net if cleanup()'s own deleteConsumer call above
+              // never runs.
+              inactiveThreshold: const Duration(minutes: 5),
             ))
+        .then((consumer) => ephemeralConsumer = consumer)
         .catchError((dynamic err) {
       controller.addError(err);
       cleanup();

--- a/lib/src/kv.dart
+++ b/lib/src/kv.dart
@@ -330,18 +330,34 @@ class KeyValue {
       inactiveThreshold: const Duration(minutes: 5),
     );
 
+    // Guards against a race between this create() call landing and the
+    // caller cancelling almost immediately: if onCancel runs first, it has
+    // no consumer name yet to delete, and nothing would call it a second
+    // time once create() finally resolves -- `cancelled` lets the create()
+    // continuation notice that and delete the consumer itself instead of
+    // leaking it for the full inactiveThreshold window.
     Consumer<dynamic>? ephemeralConsumer;
+    bool cancelled = false;
     client
         .jetStream()
         .createConsumer(streamName, consumerConfig)
-        .then((consumer) => ephemeralConsumer = consumer)
-        .catchError((dynamic err) {
+        .then((consumer) {
+      if (cancelled) {
+        client
+            .jetStream()
+            .deleteConsumer(streamName, consumer.name)
+            .catchError((_) => false);
+      } else {
+        ephemeralConsumer = consumer;
+      }
+    }).catchError((dynamic err) {
       controller.addError(err);
       controller.close();
       throw err;
     });
 
     controller.onCancel = () async {
+      cancelled = true;
       streamSub.cancel();
       client.unSub(sub);
       final consumer = ephemeralConsumer;
@@ -413,14 +429,23 @@ class KeyValue {
     StreamSubscription? streamSub;
     Timer? timeoutTimer;
     Consumer<dynamic>? ephemeralConsumer;
+    // Guards against cleanup() running (via the pending-count-reaches-zero
+    // fast path below, which can win the race against createConsumer()'s
+    // own reply on a small/already-delivered result set) before
+    // ephemeralConsumer is set -- without this, cleanup() would have
+    // nothing to delete yet, and nothing would call it a second time once
+    // createConsumer() finally resolves, leaking the consumer for the full
+    // inactiveThreshold window instead of deleting it immediately.
+    bool cleanedUp = false;
 
     void cleanup() {
+      if (cleanedUp) return;
+      cleanedUp = true;
       timeoutTimer?.cancel();
       streamSub?.cancel();
       client.unSub(sub);
       final consumer = ephemeralConsumer;
       if (consumer != null) {
-        ephemeralConsumer = null;
         client
             .jetStream()
             .deleteConsumer(streamName, consumer.name)
@@ -487,8 +512,16 @@ class KeyValue {
     });
 
     try {
-      ephemeralConsumer =
+      final consumer =
           await client.jetStream().createConsumer(streamName, consumerConfig);
+      if (cleanedUp) {
+        client
+            .jetStream()
+            .deleteConsumer(streamName, consumer.name)
+            .catchError((_) => false);
+      } else {
+        ephemeralConsumer = consumer;
+      }
     } catch (e) {
       cleanup();
       if (!completer.isCompleted) {
@@ -510,8 +543,17 @@ class KeyValue {
     StreamSubscription? streamSub;
     Timer? timeoutTimer;
     Consumer<dynamic>? ephemeralConsumer;
+    // Guards against cleanup() running (e.g. via the pending-count-reaches-
+    // zero fast path below) before createConsumer()'s reply has landed and
+    // ephemeralConsumer is set -- without this, cleanup() would have
+    // nothing to delete yet, and nothing would call it a second time once
+    // the reply finally arrives, leaking the consumer for the full
+    // inactiveThreshold window instead of deleting it immediately.
+    bool cleanedUp = false;
 
     void cleanup() {
+      if (cleanedUp) return;
+      cleanedUp = true;
       timeoutTimer?.cancel();
       streamSub?.cancel();
       client.unSub(sub);
@@ -520,7 +562,6 @@ class KeyValue {
       }
       final consumer = ephemeralConsumer;
       if (consumer != null) {
-        ephemeralConsumer = null;
         client
             .jetStream()
             .deleteConsumer(streamName, consumer.name)
@@ -594,8 +635,16 @@ class KeyValue {
               // never runs.
               inactiveThreshold: const Duration(minutes: 5),
             ))
-        .then((consumer) => ephemeralConsumer = consumer)
-        .catchError((dynamic err) {
+        .then((consumer) {
+      if (cleanedUp) {
+        client
+            .jetStream()
+            .deleteConsumer(streamName, consumer.name)
+            .catchError((_) => false);
+      } else {
+        ephemeralConsumer = consumer;
+      }
+    }).catchError((dynamic err) {
       controller.addError(err);
       cleanup();
       throw err;

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -128,6 +128,11 @@ class Message<T> {
   }
 
   /// Acknowledge the message (JetStream)
+  ///
+  /// Fire-and-forget: publishes the ack but does not wait for (or report)
+  /// whether it actually reached the server, so a disconnected client still
+  /// returns `true`. Prefer [ackSync] when the caller needs to know the ack
+  /// really landed.
   bool ack() {
     if (replyTo == null || replyTo == '') return false;
     _client.pub(replyTo, Uint8List.fromList(utf8.encode('+ACK')));
@@ -135,6 +140,8 @@ class Message<T> {
   }
 
   /// Negatively acknowledge the message (JetStream)
+  ///
+  /// Fire-and-forget: see [ack]'s doc comment. Prefer [nakSync].
   bool nak() {
     if (replyTo == null || replyTo == '') return false;
     _client.pub(replyTo, Uint8List.fromList(utf8.encode('-NAK')));
@@ -142,6 +149,8 @@ class Message<T> {
   }
 
   /// Terminate the message, preventing redelivery (JetStream)
+  ///
+  /// Fire-and-forget: see [ack]'s doc comment. Prefer [termSync].
   bool term() {
     if (replyTo == null || replyTo == '') return false;
     _client.pub(replyTo, Uint8List.fromList(utf8.encode('+TERM')));
@@ -149,6 +158,8 @@ class Message<T> {
   }
 
   /// Indicate message processing is still in progress (JetStream)
+  ///
+  /// Fire-and-forget: see [ack]'s doc comment. Prefer [inProgressSync].
   bool inProgress() {
     if (replyTo == null || replyTo == '') return false;
     _client.pub(replyTo, Uint8List.fromList(utf8.encode('+WPI')));
@@ -200,6 +211,40 @@ class Message<T> {
       throw NatsException('Cannot acknowledge message: no reply subject');
     }
     await _client.request(replyTo!, Uint8List.fromList(utf8.encode('+ACK')),
+        timeout: timeout);
+  }
+
+  /// Negatively acknowledge the message and wait for confirmation from the
+  /// JetStream server (synchronous nak) -- throws if it doesn't land, e.g.
+  /// because the client is disconnected.
+  Future<void> nakSync({Duration timeout = const Duration(seconds: 2)}) async {
+    if (replyTo == null || replyTo == '') {
+      throw NatsException('Cannot nak message: no reply subject');
+    }
+    await _client.request(replyTo!, Uint8List.fromList(utf8.encode('-NAK')),
+        timeout: timeout);
+  }
+
+  /// Terminate the message, preventing redelivery, and wait for
+  /// confirmation from the JetStream server (synchronous term) -- throws if
+  /// it doesn't land, e.g. because the client is disconnected.
+  Future<void> termSync({Duration timeout = const Duration(seconds: 2)}) async {
+    if (replyTo == null || replyTo == '') {
+      throw NatsException('Cannot terminate message: no reply subject');
+    }
+    await _client.request(replyTo!, Uint8List.fromList(utf8.encode('+TERM')),
+        timeout: timeout);
+  }
+
+  /// Indicate message processing is still in progress and wait for
+  /// confirmation from the JetStream server (synchronous in-progress) --
+  /// throws if it doesn't land, e.g. because the client is disconnected.
+  Future<void> inProgressSync(
+      {Duration timeout = const Duration(seconds: 2)}) async {
+    if (replyTo == null || replyTo == '') {
+      throw NatsException('Cannot mark message in progress: no reply subject');
+    }
+    await _client.request(replyTo!, Uint8List.fromList(utf8.encode('+WPI')),
         timeout: timeout);
   }
 }

--- a/test/jetstream_pagination_test.dart
+++ b/test/jetstream_pagination_test.dart
@@ -1,0 +1,73 @@
+import 'package:dart_nats/dart_nats.dart';
+import 'package:test/test.dart';
+
+/// nats-server caps `$JS.API.STREAM.LIST` and `$JS.API.CONSUMER.LIST.*`
+/// responses to a fixed page (256 items) regardless of how many
+/// streams/consumers actually exist, reporting the true count in the same
+/// response's `total` field. A client that never sends `offset` silently
+/// drops everything past the first page -- no error, no truncation flag.
+/// These tests create more than one page's worth of streams/consumers and
+/// confirm `listStreams()`/`listConsumers()` return the full set.
+void main() {
+  group('JetStream list pagination', () {
+    late Client client;
+    late JetStream js;
+    const streamCount = 260;
+    final prefix = 'pg-${DateTime.now().microsecondsSinceEpoch}';
+
+    setUp(() async {
+      client = Client();
+      await client.connect(Uri.parse('nats://localhost:4222'), retry: false);
+      js = client.jetStream();
+    });
+
+    tearDown(() async {
+      await client.close();
+    });
+
+    test('listStreams returns every stream past the first server page',
+        () async {
+      for (var i = 0; i < streamCount; i++) {
+        await js.createStream(StreamConfig(
+          name: '$prefix-$i',
+          subjects: ['$prefix.$i'],
+          storage: 'memory',
+        ));
+      }
+
+      try {
+        final streams =
+            await js.listStreams(timeout: const Duration(seconds: 10));
+        final ours = streams.where((s) => s.config.name.startsWith(prefix));
+        expect(ours.length, equals(streamCount));
+      } finally {
+        for (var i = 0; i < streamCount; i++) {
+          await js.deleteStream('$prefix-$i');
+        }
+      }
+    }, timeout: const Timeout(Duration(minutes: 2)));
+
+    test('listConsumers returns every consumer past the first server page',
+        () async {
+      final streamName = '$prefix-consumers';
+      await js.createStream(StreamConfig(
+        name: streamName,
+        subjects: ['$streamName.>'],
+        storage: 'memory',
+      ));
+
+      try {
+        for (var i = 0; i < streamCount; i++) {
+          await js.createConsumer(
+              streamName, ConsumerConfig(durable: 'c-$i', ackPolicy: 'none'));
+        }
+
+        final consumers = await js.listConsumers(streamName,
+            timeout: const Duration(seconds: 10));
+        expect(consumers.length, equals(streamCount));
+      } finally {
+        await js.deleteStream(streamName);
+      }
+    }, timeout: const Timeout(Duration(minutes: 2)));
+  });
+}

--- a/test/jetstream_swallowed_errors_test.dart
+++ b/test/jetstream_swallowed_errors_test.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:dart_nats/dart_nats.dart';
+import 'package:test/test.dart';
+
+/// Both `Consumer.messages()`'s pull loop and `OrderedConsumer._start()`
+/// used to swallow every failure into a silent 1-second retry loop, never
+/// calling `addError` on the stream they hand back. A caller had no way to
+/// know delivery had permanently broken (e.g. the server-side consumer was
+/// deleted out from under a pull consumer, or an OrderedConsumer's hardcoded
+/// no-ack config is rejected by a workqueue-retention stream) short of
+/// polling consumer metadata themselves. These tests confirm both surface
+/// the failure via the stream's error channel instead.
+void main() {
+  group('JetStream swallowed errors', () {
+    late Client client;
+    late JetStream js;
+    final prefix = 'swerr-${DateTime.now().microsecondsSinceEpoch}';
+
+    setUp(() async {
+      client = Client();
+      await client.connect(Uri.parse('nats://localhost:4222'), retry: false);
+      js = client.jetStream();
+    });
+
+    tearDown(() async {
+      await client.close();
+    });
+
+    test(
+        'Consumer.messages() surfaces an error after the server-side '
+        'consumer is deleted out from under it', () async {
+      final streamName = '$prefix-pull';
+      final consumerName = 'c1';
+      await js.createStream(StreamConfig(
+        name: streamName,
+        subjects: ['$streamName.>'],
+        storage: 'memory',
+      ));
+      await js.createConsumer(
+          streamName, ConsumerConfig(durable: consumerName, ackPolicy: 'none'));
+
+      final consumer = js.consumer(streamName, consumerName);
+      final errorCompleter = Completer<Object>();
+      final sub = consumer.messages(timeout: const Duration(seconds: 2)).listen(
+        (_) {},
+        onError: (Object e) {
+          if (!errorCompleter.isCompleted) errorCompleter.complete(e);
+        },
+      );
+
+      // Give the pull loop a moment to start, then delete the consumer
+      // server-side -- every subsequent fetch() must fail.
+      await Future.delayed(const Duration(milliseconds: 300));
+      await js.deleteConsumer(streamName, consumerName);
+
+      final error =
+          await errorCompleter.future.timeout(const Duration(seconds: 10));
+      expect(error, isNotNull);
+
+      await sub.cancel();
+      await js.deleteStream(streamName);
+    });
+
+    test(
+        'OrderedConsumer surfaces createConsumer rejection on a '
+        'workqueue-retention stream instead of retrying silently', () async {
+      final streamName = '$prefix-wq';
+      await js.createStream(StreamConfig(
+        name: streamName,
+        subjects: ['$streamName.>'],
+        storage: 'memory',
+        retention: 'workqueue',
+      ));
+
+      final oc = js.orderedConsumer(streamName, OrderedConsumerConfig());
+      final errorCompleter = Completer<Object>();
+      final sub = oc.messages().listen(
+        (_) {},
+        onError: (Object e) {
+          if (!errorCompleter.isCompleted) errorCompleter.complete(e);
+        },
+      );
+
+      final error =
+          await errorCompleter.future.timeout(const Duration(seconds: 5));
+      expect(error, isNotNull);
+
+      await sub.cancel();
+      oc.stop();
+      await js.deleteStream(streamName);
+    });
+  });
+}

--- a/test/kv_consumer_leak_test.dart
+++ b/test/kv_consumer_leak_test.dart
@@ -1,0 +1,86 @@
+import 'package:dart_nats/dart_nats.dart';
+import 'package:test/test.dart';
+
+/// `KeyValue.watch()`, `.history()`, and `.keys()` each create an ephemeral
+/// push consumer to receive updates, but discarded the `Consumer` object
+/// `createConsumer()` returned and never deleted it once the caller
+/// cancelled/finished -- every call left a server-side consumer behind
+/// forever. Confirms all three now clean up after themselves.
+void main() {
+  group('KeyValue ephemeral consumer cleanup', () {
+    late Client client;
+    late JetStream js;
+    late String bucket;
+    late String streamName;
+
+    setUp(() async {
+      client = Client();
+      await client.connect(Uri.parse('nats://localhost:4222'), retry: false);
+      js = client.jetStream();
+      bucket = 'kvleak${DateTime.now().microsecondsSinceEpoch}';
+      streamName = 'KV_$bucket';
+      await js.createKeyValue(
+          KeyValueConfig(bucket: bucket, storage: 'memory', history: 5));
+    });
+
+    tearDown(() async {
+      try {
+        await js.deleteStream(streamName);
+      } catch (_) {}
+      await client.close();
+    });
+
+    test('watch() deletes its ephemeral consumer on cancel', () async {
+      final kv = await js.keyValue(bucket);
+      final sub = kv.watch().listen((_) {});
+      // Let createConsumer() resolve before cancelling.
+      await Future.delayed(const Duration(milliseconds: 300));
+
+      final duringWatch = await js.listConsumers(streamName);
+      expect(duringWatch, isNotEmpty);
+
+      await sub.cancel();
+      // deleteConsumer() runs inside onCancel; give it a moment to land.
+      await Future.delayed(const Duration(milliseconds: 300));
+
+      final afterCancel = await js.listConsumers(streamName);
+      expect(afterCancel, isEmpty);
+    });
+
+    test('history() deletes its ephemeral consumer once exhausted', () async {
+      final kv = await js.keyValue(bucket);
+      await kv.putString('k', 'v1');
+      await kv.putString('k', 'v2');
+
+      final entries = await kv.history('k').toList();
+      expect(entries.length, equals(2));
+
+      // history()'s pending-count-reaches-zero fast path isn't always
+      // reliable (same as keys(), below), so cleanup() can fall back to
+      // its pre-existing 5s timeoutTimer -- wait past that worst case
+      // rather than assume the fast path fired.
+      await Future.delayed(const Duration(seconds: 6));
+
+      final consumers = await js.listConsumers(streamName);
+      expect(consumers, isEmpty);
+    });
+
+    test('keys() deletes its ephemeral consumer once done', () async {
+      final kv = await js.keyValue(bucket);
+      await kv.putString('a', '1');
+      await kv.putString('b', '2');
+
+      final keys = await kv.keys();
+      expect(keys, containsAll(['a', 'b']));
+
+      // keys()'s own pending-count-reaches-zero fast path doesn't always
+      // fire for a small result set, so cleanup() falls back to its
+      // pre-existing 5s timeoutTimer -- unrelated to the consumer-leak fix
+      // under test here, just something to wait past.
+      await Future.delayed(const Duration(seconds: 6));
+
+      final consumers = await js.listConsumers(streamName);
+      expect(consumers, isEmpty);
+    });
+  });
+}

--- a/test/kv_consumer_leak_test.dart
+++ b/test/kv_consumer_leak_test.dart
@@ -6,6 +6,26 @@ import 'package:test/test.dart';
 /// `createConsumer()` returned and never deleted it once the caller
 /// cancelled/finished -- every call left a server-side consumer behind
 /// forever. Confirms all three now clean up after themselves.
+///
+/// Waits for the empty-consumer-list outcome by polling rather than a
+/// single fixed sleep: deleteConsumer() lands asynchronously (fire-and-
+/// forget in cleanup()), and `history()`/`keys()` can fall back to their
+/// own pre-existing 5s timeoutTimer when their pending-count-reaches-zero
+/// fast path doesn't fire, so a fixed short wait is flaky under load.
+Future<void> expectEventuallyNoConsumers(JetStream js, String streamName,
+    {Duration timeout = const Duration(seconds: 15)}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (true) {
+    final consumers = await js.listConsumers(streamName);
+    if (consumers.isEmpty) return;
+    if (DateTime.now().isAfter(deadline)) {
+      fail('expected no consumers on $streamName, still have '
+          '${consumers.map((c) => c.name).toList()} after $timeout');
+    }
+    await Future.delayed(const Duration(milliseconds: 250));
+  }
+}
+
 void main() {
   group('KeyValue ephemeral consumer cleanup', () {
     late Client client;
@@ -40,11 +60,7 @@ void main() {
       expect(duringWatch, isNotEmpty);
 
       await sub.cancel();
-      // deleteConsumer() runs inside onCancel; give it a moment to land.
-      await Future.delayed(const Duration(milliseconds: 300));
-
-      final afterCancel = await js.listConsumers(streamName);
-      expect(afterCancel, isEmpty);
+      await expectEventuallyNoConsumers(js, streamName);
     });
 
     test('history() deletes its ephemeral consumer once exhausted', () async {
@@ -55,14 +71,7 @@ void main() {
       final entries = await kv.history('k').toList();
       expect(entries.length, equals(2));
 
-      // history()'s pending-count-reaches-zero fast path isn't always
-      // reliable (same as keys(), below), so cleanup() can fall back to
-      // its pre-existing 5s timeoutTimer -- wait past that worst case
-      // rather than assume the fast path fired.
-      await Future.delayed(const Duration(seconds: 6));
-
-      final consumers = await js.listConsumers(streamName);
-      expect(consumers, isEmpty);
+      await expectEventuallyNoConsumers(js, streamName);
     });
 
     test('keys() deletes its ephemeral consumer once done', () async {
@@ -73,14 +82,7 @@ void main() {
       final keys = await kv.keys();
       expect(keys, containsAll(['a', 'b']));
 
-      // keys()'s own pending-count-reaches-zero fast path doesn't always
-      // fire for a small result set, so cleanup() falls back to its
-      // pre-existing 5s timeoutTimer -- unrelated to the consumer-leak fix
-      // under test here, just something to wait past.
-      await Future.delayed(const Duration(seconds: 6));
-
-      final consumers = await js.listConsumers(streamName);
-      expect(consumers, isEmpty);
+      await expectEventuallyNoConsumers(js, streamName);
     });
   });
 }

--- a/test/message_ack_sync_test.dart
+++ b/test/message_ack_sync_test.dart
@@ -1,0 +1,117 @@
+import 'package:dart_nats/dart_nats.dart';
+import 'package:test/test.dart';
+
+/// `nak()`/`term()`/`inProgress()` (like `ack()` before it gained
+/// `ackSync()`) publish their JetStream control message via `pub()` without
+/// awaiting or returning its Future -- a disconnected client silently
+/// buffers the publish and still reports success, so a caller has no way to
+/// know the ack/nak/term never actually reached the server. These tests
+/// cover the new `nakSync()`/`termSync()`/`inProgressSync()` methods, which
+/// use the same request/reply pattern `ackSync()` already established: they
+/// wait for the server's own confirmation and throw if it doesn't arrive.
+void main() {
+  group('Message *Sync acknowledgement methods', () {
+    late Client client;
+    late JetStream js;
+    final streamName = 'acksync-${DateTime.now().microsecondsSinceEpoch}';
+
+    setUp(() async {
+      client = Client();
+      await client.connect(Uri.parse('nats://localhost:4222'), retry: false);
+      js = client.jetStream();
+      await js.createStream(StreamConfig(
+        name: streamName,
+        subjects: ['$streamName.>'],
+        storage: 'memory',
+      ));
+    });
+
+    tearDown(() async {
+      try {
+        await js.deleteStream(streamName);
+      } catch (_) {}
+      if (client.connected) await client.close();
+    });
+
+    test('nakSync() triggers immediate redelivery', () async {
+      const consumerName = 'nak-consumer';
+      await js.publishString('$streamName.a', 'payload');
+      await js.createConsumer(
+          streamName, ConsumerConfig(durable: consumerName));
+      final consumer = js.consumer(streamName, consumerName);
+
+      final first = await consumer.fetch(batch: 1);
+      expect(first, hasLength(1));
+      await first[0].nakSync();
+
+      final redelivered =
+          await consumer.fetch(batch: 1, timeout: const Duration(seconds: 3));
+      expect(redelivered, hasLength(1));
+      expect(redelivered[0].string, equals('payload'));
+    });
+
+    test('termSync() prevents redelivery', () async {
+      const consumerName = 'term-consumer';
+      await js.publishString('$streamName.b', 'payload');
+      await js.createConsumer(
+          streamName, ConsumerConfig(durable: consumerName));
+      final consumer = js.consumer(streamName, consumerName);
+
+      final first = await consumer.fetch(batch: 1);
+      expect(first, hasLength(1));
+      await first[0].termSync();
+
+      final notRedelivered =
+          await consumer.fetch(batch: 1, timeout: const Duration(seconds: 2));
+      expect(notRedelivered, isEmpty);
+
+      final info = await consumer.info();
+      expect(info.numAckPending, equals(0));
+    });
+
+    test('inProgressSync() does not throw and can be followed by ackSync()',
+        () async {
+      const consumerName = 'wpi-consumer';
+      await js.publishString('$streamName.c', 'payload');
+      await js.createConsumer(
+          streamName, ConsumerConfig(durable: consumerName));
+      final consumer = js.consumer(streamName, consumerName);
+
+      final first = await consumer.fetch(batch: 1);
+      expect(first, hasLength(1));
+      await first[0].inProgressSync();
+      await first[0].ackSync();
+
+      final info = await consumer.info();
+      expect(info.numAckPending, equals(0));
+    });
+
+    test(
+        'nakSync()/termSync()/inProgressSync() throw when the client is '
+        'disconnected instead of silently reporting success', () async {
+      const consumerName = 'disconnected-consumer';
+      await js.publishString('$streamName.d', 'payload');
+      await js.createConsumer(
+          streamName, ConsumerConfig(durable: consumerName));
+      final consumer = js.consumer(streamName, consumerName);
+
+      final first = await consumer.fetch(batch: 1);
+      expect(first, hasLength(1));
+      final msg = first[0];
+
+      await client.close();
+
+      expect(() => msg.nakSync(), throwsA(isA<NatsException>()));
+      expect(() => msg.termSync(), throwsA(isA<NatsException>()));
+      expect(() => msg.inProgressSync(), throwsA(isA<NatsException>()));
+
+      // Contrast: the old fire-and-forget methods report success anyway --
+      // pub() silently buffers the publish for a future reconnect that may
+      // never happen, rather than failing loudly. Documents exactly the
+      // bug these Sync variants exist to fix, not desired behavior.
+      expect(msg.nak(), isTrue);
+      expect(msg.term(), isTrue);
+      expect(msg.inProgress(), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Four bugs found while using dart_nats in a downstream app, each with its own commit and test.

**`listStreams()`/`listConsumers()` silently drop everything past 256 items.** nats-server pages list responses, but neither method sends `offset`, so accounts with more than one page's worth of streams/consumers just lose visibility into the rest. Now paginates properly.

**Pull consumers and `OrderedConsumer` retry forever without ever saying why.** Both caught every error and just silently retried every second. A deleted pull consumer doesn't even throw - `fetch()` just times out with an empty batch, identical to a healthy idle consumer. Now double-checks the consumer still exists whenever a batch comes back empty, and both surface errors via `addError()` instead of eating them.

**`KeyValue.watch()`/`history()`/`keys()` leak a consumer every call.** Each creates an ephemeral consumer and never deletes it, so every watch/refresh leaves one behind on the server forever. Fixed, plus a new `inactiveThreshold` config field as a safety net for the "client crashed uncleanly" case. Testing this also caught a race in the fix itself — cleanup could run before the consumer's create response came back, orphaning it anyway — so that's fixed too.

**Added `nakSync()`/`termSync()`/`inProgressSync()`.** `ack()`/`nak()`/`term()`/`inProgress()` fire off their publish without waiting for it, so a disconnected client reports success even though nothing reached the server. `ackSync()` already exists for exactly this; added the same for the other three instead of changing the existing methods' signatures (which would've been breaking).

## Testing

`dart analyze` + full `dart test -j1` clean (166 tests, including the new ones this PR adds). Also verified end-to-end against a real downstream Flutter app by pointing its pubspec at this branch — its own test suite and live-server integration tests all pass too.
