### PR TITLE
fix: background reconnect can stall or stop after network loss

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'platform/platform.dart';
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:mutex/mutex.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -169,6 +170,16 @@ class Client {
   int _reconnectCount = 3;
   bool _wasConnected = false;
   bool _reconnecting = false;
+  /// True while completing a background reconnect cycle (for [onReconnect]).
+  bool _reconnectCycle = false;
+
+  /// Override for [Socket.connect] used by tests to simulate connect failures.
+  /// Return a platform [Socket] (or throw) — typed as [Object] so VM/web stubs unify.
+  @visibleForTesting
+  Future<Object> Function(String host, int port, {Duration? timeout})?
+      debugSocketConnect;
+
+  static const Duration _socketCleanupTimeout = Duration(seconds: 2);
 
   int _ssid = 0;
   int _connectionId = 0;
@@ -583,7 +594,7 @@ class Client {
           if (port == 0) {
             port = 4222;
           }
-          _tcpSocket = await Socket.connect(
+          _tcpSocket = await _socketConnect(
             uri.host,
             port,
             timeout: Duration(seconds: timeout),
@@ -605,6 +616,7 @@ class Client {
             if (onError != null) {
               onError!(e);
             }
+            _setStatus(Status.disconnected);
           }).onDone(() {
             if (currentSocket != _tcpSocket) return;
             _setStatus(Status.disconnected);
@@ -616,7 +628,7 @@ class Client {
           if (port == 0) {
             port = 4443;
           }
-          _tcpSocket = await Socket.connect(
+          _tcpSocket = await _socketConnect(
             uri.host,
             port,
             timeout: Duration(seconds: timeout),
@@ -636,6 +648,7 @@ class Client {
             if (onError != null) {
               onError!(e);
             }
+            _setStatus(Status.disconnected);
           });
           return true;
 
@@ -1272,7 +1285,6 @@ class Client {
         }
       }
     }
-    final oldStatus = _status;
     _status = newStatus;
     _statusController.add(newStatus);
 
@@ -1294,11 +1306,12 @@ class Client {
         _pingsOut++;
         _add('ping');
       });
-      if (oldStatus == Status.reconnecting && onReconnect != null) {
+      if (_reconnectCycle && onReconnect != null) {
         onReconnect!();
-      } else if (onConnect != null) {
+      } else if (!_reconnectCycle && onConnect != null) {
         onConnect!();
       }
+      _reconnectCycle = false;
     } else if (newStatus == Status.disconnected) {
       _pingTimer?.cancel();
       _pingTimer = null;
@@ -1311,6 +1324,8 @@ class Client {
       }
     } else if (newStatus == Status.closed) {
       _wasConnected = false;
+      _reconnectCycle = false;
+      _reconnecting = false;
       _pingTimer?.cancel();
       _pingTimer = null;
       _pingsOut = 0;
@@ -1323,6 +1338,7 @@ class Client {
   void _reconnectLoopBackground() async {
     if (_reconnecting) return;
     _reconnecting = true;
+    _reconnectCycle = true;
 
     int attempts = 0;
     final maxAttempts = _reconnectCount == -1
@@ -1330,7 +1346,8 @@ class Client {
         : _reconnectCount * _serverPool.length;
 
     while (_retry &&
-        status == Status.disconnected &&
+        status != Status.connected &&
+        status != Status.closed &&
         (attempts < maxAttempts || maxAttempts == -1)) {
       _setStatus(Status.reconnecting);
       final currentUri = _getNextServer();
@@ -1349,23 +1366,37 @@ class Client {
           return;
         }
       } catch (err) {
-        await _cleanUpSockets();
+        await _cleanUpSocketsSoft();
         if (onError != null) {
           onError!(err);
         }
       }
       attempts++;
       if (_retry &&
-          status == Status.disconnected &&
+          status != Status.connected &&
+          status != Status.closed &&
           (attempts < maxAttempts || maxAttempts == -1)) {
         await Future<void>.delayed(Duration(seconds: _reconnectInterval));
       }
     }
 
     _reconnecting = false;
-    if (status == Status.disconnected) {
+    _reconnectCycle = false;
+    if (status != Status.connected && status != Status.closed) {
       await close();
     }
+  }
+
+  Future<Socket> _socketConnect(
+    String host,
+    int port, {
+    Duration? timeout,
+  }) async {
+    final override = debugSocketConnect;
+    if (override != null) {
+      return await override(host, port, timeout: timeout) as Socket;
+    }
+    return Socket.connect(host, port, timeout: timeout);
   }
 
   Future<void> _cleanUpSockets() async {
@@ -1380,6 +1411,28 @@ class Client {
     final tcp = _tcpSocket;
     _tcpSocket = null;
     await tcp?.close();
+  }
+
+  /// Null socket refs first, then close with a short timeout so reconnect
+  /// retries cannot hang on a zombie TCP close after abrupt network loss.
+  Future<void> _cleanUpSocketsSoft() async {
+    final ws = _wsChannel;
+    _wsChannel = null;
+    final secure = _secureSocket;
+    _secureSocket = null;
+    final tcp = _tcpSocket;
+    _tcpSocket = null;
+
+    Future<void> closeQuietly(Future<dynamic>? closing) async {
+      if (closing == null) return;
+      try {
+        await closing.timeout(_socketCleanupTimeout);
+      } catch (_) {}
+    }
+
+    await closeQuietly(ws?.sink.close());
+    await closeQuietly(secure?.close());
+    await closeQuietly(tcp?.close());
   }
 
   /// Close connection and prevent any future reconnect retries

--- a/test/connect_test.dart
+++ b/test/connect_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:dart_nats/dart_nats.dart';
@@ -103,6 +104,87 @@ void main() {
       expect(result, true);
       msg = await sub.stream.first;
       expect(String.fromCharCodes(msg.byte), equals('message2'));
+      await client.close();
+    });
+
+    test('background reconnect retries after failed Socket.connect', () async {
+      var client = Client();
+      var connectCalls = 0;
+      var onConnectCount = 0;
+      var onReconnectCount = 0;
+      final attemptTimes = <DateTime>[];
+
+      client.onConnect = () => onConnectCount++;
+      client.onReconnect = () => onReconnectCount++;
+
+      await client.connect(
+        Uri.parse('nats://localhost:4222'),
+        retry: true,
+        retryCount: -1,
+        timeout: 2,
+        retryInterval: 1,
+      );
+      expect(client.status, equals(Status.connected));
+      expect(onConnectCount, equals(1));
+      expect(onReconnectCount, equals(0));
+
+      const failCount = 3;
+      client.debugSocketConnect = (host, port, {timeout}) async {
+        connectCalls++;
+        attemptTimes.add(DateTime.now());
+        if (connectCalls <= failCount) {
+          throw Exception('Simulated offline connect failure');
+        }
+        return Socket.connect(host, port, timeout: timeout);
+      };
+
+      await client.tcpClose();
+      await client.waitUntilConnected().timeout(const Duration(seconds: 15));
+
+      expect(client.status, equals(Status.connected));
+      expect(connectCalls, greaterThan(failCount));
+      expect(onReconnectCount, equals(1));
+      expect(onConnectCount, equals(1));
+
+      // retryInterval is 1s; failures should be spaced by ~1s (not busy-spin).
+      expect(attemptTimes.length, greaterThanOrEqualTo(2));
+      final gap = attemptTimes[1].difference(attemptTimes[0]);
+      expect(gap.inMilliseconds, greaterThanOrEqualTo(800));
+
+      var sub = client.sub('reconnect_fail_then_ok');
+      await client.pub(
+          'reconnect_fail_then_ok', Uint8List.fromList('ok'.codeUnits));
+      var msg = await sub.stream.first.timeout(const Duration(seconds: 5));
+      expect(String.fromCharCodes(msg.byte), equals('ok'));
+
+      client.debugSocketConnect = null;
+      await client.close();
+    });
+
+    test('successful reconnect fires onReconnect not onConnect', () async {
+      var client = Client();
+      var onConnectCount = 0;
+      var onReconnectCount = 0;
+      client.onConnect = () => onConnectCount++;
+      client.onReconnect = () => onReconnectCount++;
+
+      await client.connect(
+        Uri.parse('nats://localhost:4222'),
+        retry: true,
+        retryCount: -1,
+        retryInterval: 1,
+      );
+      expect(onConnectCount, equals(1));
+      expect(onReconnectCount, equals(0));
+
+      await client.tcpClose();
+      await client.waitUntilConnected();
+
+      expect(client.status, equals(Status.connected));
+      expect(onReconnectCount, equals(1));
+      expect(onConnectCount, equals(1));
+
+      await client.close();
     });
     test('status stream', () async {
       var client = Client();


### PR DESCRIPTION
When the NATS TCP connection drops abruptly (e.g. airplane mode / network loss), the client’s background reconnect may stop retrying or hang, so it never returns to Status.connected even with retry: true and retryCount: -1.

What was detected
The loop condition requires status == Status.disconnected. During retries the client sets Status.reconnecting, so after a failed attempt the condition is no longer true and the loop stops, even though reconnect should keep going.

On failure, cleanup awaits Socket.close() with no timeout. After an abrupt drop, that close can hang on a “zombie” TCP socket, so the next reconnect attempt never runs.

Some error paths don’t set Status.disconnected, and onReconnect vs onConnect can fire incorrectly because success is inferred from the previous status being reconnecting.