### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,12 @@ jobs:
       - name: Analyze
         run: dart analyze
       - name: Check formatting
-        run: dart format --output=none --set-exit-if-changed .
+        # Scoped to the package's own source, not the whole repo tree:
+        # example/demo is a separate Flutter app whose analysis_options.yaml
+        # can't resolve flutter_lints without a `flutter pub get`, which
+        # makes `dart format` fall back to a language version too old for
+        # its super-parameter syntax and fail to parse it.
+        run: dart format --output=none --set-exit-if-changed lib test example/*.dart
       - name: Generate TLS test certificates
         run: |
           openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
             -out test/config/server-cert.pem \
             -keyout test/config/server-key.pem \
             -subj "/C=US/ST=State/L=City/O=Organization/OU=OrgUnit/CN=localhost"
+      - name: Install NATS CLI
+        # test/interop_test.dart shells out to the official `nats` CLI to
+        # verify interop with this package -- not preinstalled on runners.
+        run: |
+          curl -sf https://binaries.nats.dev/nats-io/natscli/nats@latest | sh
+          sudo mv ./nats /usr/local/bin/nats
+          nats --version
       - name: Start NATS test infrastructure
         run: docker compose up -d
       - name: Wait for NATS to accept connections

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,125 @@
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+      - name: Install dependencies
+        run: dart pub get
+      - name: Analyze
+        run: dart analyze
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
+      - name: Generate TLS test certificates
+        run: |
+          openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 \
+            -out test/config/server-cert.pem \
+            -keyout test/config/server-key.pem \
+            -subj "/C=US/ST=State/L=City/O=Organization/OU=OrgUnit/CN=localhost"
+      - name: Start NATS test infrastructure
+        run: docker compose up -d
+      - name: Wait for NATS to accept connections
+        run: |
+          timeout 30 bash -c 'until (echo > /dev/tcp/localhost/4222) 2>/dev/null; do sleep 1; done'
+      - name: Run test suite
+        # Tests share subjects on the same shared servers -- must run with a
+        # single job/concurrency of 1, or parallel runs cause test pollution
+        # (see DEVELOPMENT.md / Makefile's `test` target).
+        run: dart test -j 1
+      - name: Stop NATS test infrastructure
+        if: always()
+        run: docker compose down
+  analyze-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install dependencies
+        run: dart pub get
+      - name: Analyze
+        # Windows/macOS don't run the Docker-backed live-server suite (Docker
+        # isn't practical on macOS runners and adds little on Windows) -- this
+        # just catches breakage in lib/src/platform/'s conditional imports.
+        run: dart analyze
+  analyze-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install dependencies
+        run: dart pub get
+      - name: Analyze
+        run: dart analyze
+  package-validate:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install dependencies
+        run: dart pub get
+      - name: Validate package is publishable
+        run: dart pub publish --dry-run
+  publish:
+    needs: [test, analyze-windows, analyze-macos, package-validate]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    environment: pub.dev
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install dependencies
+        run: dart pub get
+      - name: Verify tag matches pubspec version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PUBSPEC_VERSION="$(grep -m1 '^version:' pubspec.yaml | sed 's/version:[[:space:]]*//')"
+          if [ "$TAG_VERSION" != "$PUBSPEC_VERSION" ]; then
+            echo "Tag v$TAG_VERSION does not match pubspec.yaml version $PUBSPEC_VERSION" >&2
+            exit 1
+          fi
+          if ! grep -q "^## $PUBSPEC_VERSION\$" CHANGELOG.md; then
+            echo "CHANGELOG.md has no '## $PUBSPEC_VERSION' entry" >&2
+            exit 1
+          fi
+          echo "PUBSPEC_VERSION=$PUBSPEC_VERSION" >> "$GITHUB_ENV"
+      - name: Publish to pub.dev
+        run: dart pub publish --force
+      - name: Extract changelog section
+        run: |
+          awk '/^## /{if (p) exit; if ($0 == "## '"$PUBSPEC_VERSION"'") p=1; next} p' CHANGELOG.md > release_notes.md
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body_path: release_notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.0
+
+* Add consumer pause/resume support (NATS 2.11+): `JetStream.pauseConsumer(stream, consumer, pauseUntil)` and `JetStream.resumeConsumer(stream, consumer)`, calling `$JS.API.CONSUMER.PAUSE`. `ConsumerInfo` also gains `paused`/`pauseUntil` fields reflecting the consumer's current pause state.
+* Add GitHub Actions CI (test suite against local NATS containers, analyze/format checks, cross-platform analyze jobs, publish dry-run) and automated `pub.dev` publishing on tagged releases.
+
 ## 1.2.4
 
 * Update package homepage and repository URLs to point to the new `dart-nats` GitHub organization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add consumer pause/resume support (NATS 2.11+): `JetStream.pauseConsumer(stream, consumer, pauseUntil)` and `JetStream.resumeConsumer(stream, consumer)`, calling `$JS.API.CONSUMER.PAUSE`. `ConsumerInfo` also gains `paused`/`pauseUntil` fields reflecting the consumer's current pause state.
 * Add GitHub Actions CI (test suite against local NATS containers, analyze/format checks, cross-platform analyze jobs, publish dry-run) and automated `pub.dev` publishing on tagged releases.
+* Fix heartbeat pings (`pingInterval`/`maxPingsOut`) never confirming a PONG reply actually arrived before counting toward the missed-ping limit, so a connection that was responding perfectly fine still got force-disconnected after `maxPingsOut` heartbeat ticks. The periodic heartbeat now tracks its PONG the same way `Client.ping()` does and resets the missed-ping counter on receipt.
 
 ## 1.2.4
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,7 @@
+analyzer:
+  exclude:
+    - example/demo/**
+
 linter:
   rules:
      - public_member_api_docs

--- a/lib/dart_nats.dart
+++ b/lib/dart_nats.dart
@@ -10,4 +10,3 @@ export 'src/jetstream.dart';
 export 'src/kv.dart';
 export 'src/object_store.dart';
 export 'src/micro.dart';
-

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1309,6 +1309,13 @@ class Client {
           return;
         }
         _pingsOut++;
+        final completer = Completer<void>();
+        _pingCompleters.add(completer);
+        // A PONG reply proves the connection is alive -- reset the missed-
+        // ping counter. Without this, _pingsOut only ever increases and the
+        // heartbeat unconditionally disconnects after maxPingsOut ticks
+        // regardless of whether the server is actually responding.
+        completer.future.then((_) => _pingsOut = 0, onError: (_) {});
         _add('ping');
       });
       if (_reconnectCycle && onReconnect != null) {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -155,6 +155,7 @@ class Client {
   final _subs = <int, Subscription>{};
   final _backendSubs = <int, bool>{};
   final _pubBuffer = <_Pub>[];
+
   /// Heartbeat ping interval duration
   Duration pingInterval = const Duration(seconds: 120);
 
@@ -170,6 +171,7 @@ class Client {
   int _reconnectCount = 3;
   bool _wasConnected = false;
   bool _reconnecting = false;
+
   /// True while completing a background reconnect cycle (for [onReconnect]).
   bool _reconnectCycle = false;
 
@@ -1344,9 +1346,8 @@ class Client {
     _reconnectCycle = true;
 
     int attempts = 0;
-    final maxAttempts = _reconnectCount == -1
-        ? -1
-        : _reconnectCount * _serverPool.length;
+    final maxAttempts =
+        _reconnectCount == -1 ? -1 : _reconnectCount * _serverPool.length;
 
     while (_retry &&
         status != Status.connected &&

--- a/lib/src/jetstream.dart
+++ b/lib/src/jetstream.dart
@@ -364,6 +364,12 @@ class ConsumerInfo {
   /// Number of redelivered messages
   final int numRedelivered;
 
+  /// Whether the consumer is currently paused (NATS 2.11+, via [JetStream.pauseConsumer])
+  final bool paused;
+
+  /// When the current pause expires, if [paused] is true
+  final DateTime? pauseUntil;
+
   /// Constructor for ConsumerInfo
   ConsumerInfo({
     required this.type,
@@ -375,6 +381,8 @@ class ConsumerInfo {
     required this.numWaiting,
     required this.numAckPending,
     required this.numRedelivered,
+    this.paused = false,
+    this.pauseUntil,
   });
 
   /// Factory from JSON map
@@ -396,6 +404,44 @@ class ConsumerInfo {
       numWaiting: json['num_waiting'] as int? ?? 0,
       numAckPending: json['num_ack_pending'] as int? ?? 0,
       numRedelivered: json['num_redelivered'] as int? ?? 0,
+      paused: json['paused'] as bool? ?? false,
+      pauseUntil: json['pause_until'] != null
+          ? DateTime.tryParse(json['pause_until'] as String)
+          : null,
+    );
+  }
+}
+
+/// Response to [JetStream.pauseConsumer]/[JetStream.resumeConsumer], mirroring
+/// the server's `io.nats.jetstream.api.v1.consumer_pause_response`.
+class ConsumerPauseResponse {
+  /// Whether the consumer is now paused
+  final bool paused;
+
+  /// When the pause expires, if [paused] is true
+  final DateTime? pauseUntil;
+
+  /// Time remaining on the pause, if [paused] is true
+  final Duration? pauseRemaining;
+
+  /// Constructor for ConsumerPauseResponse
+  ConsumerPauseResponse({
+    required this.paused,
+    this.pauseUntil,
+    this.pauseRemaining,
+  });
+
+  /// Factory from JSON map
+  factory ConsumerPauseResponse.fromJson(Map<String, dynamic> json) {
+    final pauseRemainingNanos = json['pause_remaining'] as num?;
+    return ConsumerPauseResponse(
+      paused: json['paused'] as bool? ?? false,
+      pauseUntil: json['pause_until'] != null
+          ? DateTime.tryParse(json['pause_until'] as String)
+          : null,
+      pauseRemaining: pauseRemainingNanos != null
+          ? Duration(microseconds: (pauseRemainingNanos / 1000).round())
+          : null,
     );
   }
 }
@@ -759,6 +805,42 @@ class JetStream {
       throw NatsException(map['error']['description'] as String);
     }
     return true;
+  }
+
+  /// Pause a consumer until [pauseUntil] (NATS 2.11+), suspending message
+  /// delivery/pull-ability without deleting the consumer. Calls
+  /// `\$JS.API.CONSUMER.PAUSE.<stream>.<consumer>` with a `pause_until` time.
+  /// Use [resumeConsumer] (or pass a time already in the past) to unpause.
+  Future<ConsumerPauseResponse> pauseConsumer(
+      String streamName, String consumerName, DateTime pauseUntil,
+      {Duration timeout = const Duration(seconds: 2)}) async {
+    final subject = '\$JS.API.CONSUMER.PAUSE.$streamName.$consumerName';
+    final payload = utf8.encode(
+        jsonEncode({'pause_until': pauseUntil.toUtc().toIso8601String()}));
+    final response = await client.request(subject, Uint8List.fromList(payload),
+        timeout: timeout);
+    final map = jsonDecode(response.string);
+    if (map['error'] != null) {
+      throw NatsException(map['error']['description'] as String);
+    }
+    return ConsumerPauseResponse.fromJson(map as Map<String, dynamic>);
+  }
+
+  /// Resume a previously-[pauseConsumer]-paused consumer immediately, by
+  /// sending the same `\$JS.API.CONSUMER.PAUSE` request with no `pause_until`
+  /// (the server's documented way to clear an active pause).
+  Future<ConsumerPauseResponse> resumeConsumer(
+      String streamName, String consumerName,
+      {Duration timeout = const Duration(seconds: 2)}) async {
+    final subject = '\$JS.API.CONSUMER.PAUSE.$streamName.$consumerName';
+    final response = await client.request(
+        subject, Uint8List.fromList(utf8.encode(jsonEncode({}))),
+        timeout: timeout);
+    final map = jsonDecode(response.string);
+    if (map['error'] != null) {
+      throw NatsException(map['error']['description'] as String);
+    }
+    return ConsumerPauseResponse.fromJson(map as Map<String, dynamic>);
   }
 
   /// Pull a batch of messages from a pull consumer (Deprecated: Use consumer(stream, consumer).fetch() instead)

--- a/lib/src/micro.dart
+++ b/lib/src/micro.dart
@@ -256,8 +256,7 @@ class PingResponse {
       id: json['id'] as String,
       name: json['name'] as String,
       version: json['version'] as String,
-      metadata:
-          (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
+      metadata: (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
     );
   }
 }
@@ -285,8 +284,7 @@ class EndpointInfo {
     return EndpointInfo(
       name: json['name'] as String,
       subject: json['subject'] as String,
-      metadata:
-          (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
+      metadata: (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
     );
   }
 }
@@ -328,8 +326,7 @@ class InfoResponse {
       name: json['name'] as String,
       version: json['version'] as String,
       description: json['description'] as String? ?? '',
-      metadata:
-          (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
+      metadata: (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
       endpoints: (json['endpoints'] as List? ?? const [])
           .map((e) => EndpointInfo.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -430,8 +427,7 @@ class StatsResponse {
       name: json['name'] as String,
       version: json['version'] as String,
       started: DateTime.parse(json['started'] as String),
-      metadata:
-          (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
+      metadata: (json['metadata'] as Map?)?.cast<String, String>() ?? const {},
       endpoints: (endpointsList ?? const [])
           .map((e) => EndpointStatsInfo.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_nats
 description: A Dart client for the NATS messaging system. Design to use with Dart and flutter.
-version: 1.2.4
+version: 1.3.0
 homepage: https://github.com/dart-nats
 repository: https://github.com/dart-nats/dart-nats
 

--- a/test/api_enhancements_test.dart
+++ b/test/api_enhancements_test.dart
@@ -521,7 +521,8 @@ SUACSSL3UAHUDXKFSNVUZRF5UHPMWZ6BFDTJ7M6USDXIEDNPPQYYYCU3VY
       await client.close();
     });
 
-    test('NATS Microservices Framework (ADR-32) endpoints & monitoring', () async {
+    test('NATS Microservices Framework (ADR-32) endpoints & monitoring',
+        () async {
       final client = Client();
       await client.connect(Uri.parse('nats://localhost:4222'), retry: false);
 
@@ -546,20 +547,23 @@ SUACSSL3UAHUDXKFSNVUZRF5UHPMWZ6BFDTJ7M6USDXIEDNPPQYYYCU3VY
       expect(resp.string, equals('hello-response'));
 
       // 2. Query PING
-      final pingResp = await client.requestString('\$SRV.PING.test-service', '');
+      final pingResp =
+          await client.requestString('\$SRV.PING.test-service', '');
       final pingMap = jsonDecode(pingResp.string);
       expect(pingMap['name'], equals('test-service'));
       expect(pingMap['version'], equals('1.2.3'));
 
       // 3. Query INFO
-      final infoResp = await client.requestString('\$SRV.INFO.test-service', '');
+      final infoResp =
+          await client.requestString('\$SRV.INFO.test-service', '');
       final infoMap = jsonDecode(infoResp.string);
       expect(infoMap['name'], equals('test-service'));
       expect(infoMap['description'], equals('Test Microservice'));
       expect(infoMap['endpoints'][0]['name'], equals('hello'));
 
       // 4. Query STATS
-      final statsResp = await client.requestString('\$SRV.STATS.test-service', '');
+      final statsResp =
+          await client.requestString('\$SRV.STATS.test-service', '');
       final statsMap = jsonDecode(statsResp.string);
       expect(statsMap['name'], equals('test-service'));
       final epStats = statsMap['stats']['endpoints'][0];
@@ -576,11 +580,9 @@ SUACSSL3UAHUDXKFSNVUZRF5UHPMWZ6BFDTJ7M6USDXIEDNPPQYYYCU3VY
       await client.connect(Uri.parse('nats://localhost:4222'), retry: false);
 
       final instance1 = Client();
-      await instance1.connect(Uri.parse('nats://localhost:4222'),
-          retry: false);
+      await instance1.connect(Uri.parse('nats://localhost:4222'), retry: false);
       final instance2 = Client();
-      await instance2.connect(Uri.parse('nats://localhost:4222'),
-          retry: false);
+      await instance2.connect(Uri.parse('nats://localhost:4222'), retry: false);
 
       final service1 = await instance1.addService(ServiceConfig(
         name: 'discovery-fanout-service',
@@ -647,8 +649,8 @@ SUACSSL3UAHUDXKFSNVUZRF5UHPMWZ6BFDTJ7M6USDXIEDNPPQYYYCU3VY
       expect(infoReplies.single.description,
           equals('Discovery detail test service'));
       expect(infoReplies.single.endpoints.single.name, equals('echo'));
-      expect(
-          infoReplies.single.endpoints.single.subject, equals('discovery.echo'));
+      expect(infoReplies.single.endpoints.single.subject,
+          equals('discovery.echo'));
 
       final statsReplies =
           await client.getServicesStats(name: 'discovery-detail-service');

--- a/test/jetstream_account_info_parsing_test.dart
+++ b/test/jetstream_account_info_parsing_test.dart
@@ -3,8 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('AccountInfo.fromJson', () {
-    test('reads usage/limits from the top level of a single-tier response',
-        () {
+    test('reads usage/limits from the top level of a single-tier response', () {
       // Captured verbatim from a live `nats:latest -js` server's
       // `$JS.API.INFO` response after creating one stream. Single-tier
       // (non-multi-tenant) accounts — the common case — have no `tier` key
@@ -36,7 +35,8 @@ void main() {
       expect(info.tiers, isEmpty);
     });
 
-    test('parses multi-tier accounts into the tiers map, keeping the '
+    test(
+        'parses multi-tier accounts into the tiers map, keeping the '
         'top-level fields as the account-wide aggregate', () {
       final json = {
         'streams': 2,

--- a/test/jetstream_test.dart
+++ b/test/jetstream_test.dart
@@ -447,6 +447,56 @@ void main() {
       await js.deleteStream(streamName);
     });
 
+    test('Consumer Pause/Resume', () async {
+      final streamName = 'pause-resume-test';
+      final subject = 'pause.resume.subj';
+
+      final stream = await js.createStream(StreamConfig(
+        name: streamName,
+        subjects: [subject],
+        storage: 'memory',
+      ));
+
+      final consumerName = 'pause-resume-cons';
+      final consumer = await stream.createConsumer(ConsumerConfig(
+        durable: consumerName,
+        ackPolicy: 'explicit',
+        deliverPolicy: 'all',
+      ));
+
+      await js.publishString(subject, 'before-pause');
+
+      // 1. pauseConsumer
+      final pauseUntil =
+          DateTime.now().toUtc().add(const Duration(seconds: 30));
+      final pauseResponse =
+          await js.pauseConsumer(streamName, consumerName, pauseUntil);
+      expect(pauseResponse.paused, isTrue);
+
+      final pausedInfo = await js.consumerInfo(streamName, consumerName);
+      expect(pausedInfo.paused, isTrue);
+
+      // While paused, a pull fetch gets nothing back rather than the pending message.
+      final fetchWhilePaused = await consumer.fetch(
+          batch: 1, timeout: const Duration(milliseconds: 500));
+      expect(fetchWhilePaused, isEmpty);
+
+      // 2. resumeConsumer
+      final resumeResponse = await js.resumeConsumer(streamName, consumerName);
+      expect(resumeResponse.paused, isFalse);
+
+      final resumedInfo = await js.consumerInfo(streamName, consumerName);
+      expect(resumedInfo.paused, isFalse);
+
+      // Now the pending message can actually be pulled.
+      final fetchAfterResume = await consumer.fetch(batch: 1);
+      expect(fetchAfterResume.length, equals(1));
+      expect(fetchAfterResume[0].string, equals('before-pause'));
+
+      await js.deleteConsumer(streamName, consumerName);
+      await js.deleteStream(streamName);
+    });
+
     test('Account Info details', () async {
       final streamName = 'account-info-test';
       await js.createStream(StreamConfig(

--- a/test/structure_test.dart
+++ b/test/structure_test.dart
@@ -86,8 +86,8 @@ void main() {
       var client = Client();
       var s1 = Student('id', 'name', 1);
       await client.connect(Uri.parse('ws://localhost:8080'));
-      var receive =
-          await client.requestString('structure_service', jsonEncode(s1.toJson()));
+      var receive = await client.requestString(
+          'structure_service', jsonEncode(s1.toJson()));
       var s2 = Student.fromJson(jsonDecode(receive.string));
       await client.close();
       await server.close();


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI: tests against real NATS containers, cross-platform analyze, format check, publish dry-run
- Add tag-triggered pub.dev publishing (OIDC, manual-approval gate)
- Add JetStream consumer pause/resume (`$JS.API.CONSUMER.PAUSE`), bump to 1.3.0
- Fix heartbeat pings never resetting the missed-ping counter on a real PONG, causing spurious disconnects