### PR TITLE
Filtered stream purge, Object Store streaming, and CI Node 20 fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
@@ -62,7 +62,7 @@ jobs:
   analyze-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
@@ -76,7 +76,7 @@ jobs:
   analyze-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
@@ -88,7 +88,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
@@ -105,7 +105,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.0
+
+* Add filtered/keep/seq-bounded stream purge: `JsStream.purge()`/`JetStream.purgeStream()` now accept optional `filter`, `keep`, and `seq` parameters (`$JS.API.STREAM.PURGE`'s own options), instead of only supporting an all-or-nothing purge.
+* Add `ObjectStore.putStream()`/`getStream()` for uploading/downloading objects as a `Stream<List<int>>`/`Stream<Uint8List>` without buffering the whole payload in memory, computing the SHA-256 digest incrementally as chunks arrive.
+* Fix `ObjectStore.put()`/`putStream()` leaving a previous object's chunks orphaned in the backing stream when overwriting an existing name -- the old version's chunks are now purged once the new version is safely written.
+* Bump `actions/checkout`/`actions/cache` in CI to versions that don't trigger GitHub's Node 20 deprecation warning.
+
 ## 1.3.0
 
 * Add consumer pause/resume support (NATS 2.11+): `JetStream.pauseConsumer(stream, consumer, pauseUntil)` and `JetStream.resumeConsumer(stream, consumer)`, calling `$JS.API.CONSUMER.PAUSE`. `ConsumerInfo` also gains `paused`/`pauseUntil` fields reflecting the consumer's current pause state.

--- a/lib/src/jetstream.dart
+++ b/lib/src/jetstream.dart
@@ -636,16 +636,35 @@ class JetStream {
   /// Purge a stream (Deprecated: Use stream(streamName).purge() instead)
   @Deprecated('Use stream(streamName).purge() instead')
   Future<bool> purgeStream(String streamName,
-      {Duration timeout = const Duration(seconds: 2)}) {
-    return _purgeStream(streamName, timeout: timeout);
+      {String? filter,
+      int? keep,
+      int? seq,
+      Duration timeout = const Duration(seconds: 2)}) {
+    return _purgeStream(streamName,
+        filter: filter, keep: keep, seq: seq, timeout: timeout);
   }
 
-  /// Internal purge helper
+  /// Internal purge helper.
+  ///
+  /// [filter] limits the purge to messages on a matching subject. [keep]
+  /// retains the newest N messages (of those matching [filter], if given)
+  /// instead of purging everything. [seq] purges all messages up to but
+  /// not including that sequence number. [keep] and [seq] are mutually
+  /// exclusive per the server's own API.
   Future<bool> _purgeStream(String streamName,
-      {Duration timeout = const Duration(seconds: 2)}) async {
+      {String? filter,
+      int? keep,
+      int? seq,
+      Duration timeout = const Duration(seconds: 2)}) async {
     final subject = '\$JS.API.STREAM.PURGE.$streamName';
-    final response =
-        await client.request(subject, Uint8List.fromList([]), timeout: timeout);
+    final body = <String, dynamic>{};
+    if (filter != null) body['filter'] = filter;
+    if (keep != null) body['keep'] = keep;
+    if (seq != null) body['seq'] = seq;
+    final payload = body.isEmpty
+        ? Uint8List.fromList([])
+        : Uint8List.fromList(utf8.encode(jsonEncode(body)));
+    final response = await client.request(subject, payload, timeout: timeout);
     final map = jsonDecode(response.string);
     if (map['error'] != null) {
       throw NatsException(map['error']['description'] as String);
@@ -1274,9 +1293,18 @@ class JsStream {
     return js.streamInfo(name, timeout: timeout);
   }
 
-  /// Purge all messages from this stream
-  Future<bool> purge({Duration timeout = const Duration(seconds: 2)}) {
-    return js._purgeStream(name, timeout: timeout);
+  /// Purge messages from this stream. With no arguments, purges everything.
+  /// [filter] limits the purge to a matching subject, [keep] retains the
+  /// newest N messages instead of purging all matches, and [seq] purges
+  /// everything up to but not including that sequence number ([keep] and
+  /// [seq] are mutually exclusive per the server's own API).
+  Future<bool> purge(
+      {String? filter,
+      int? keep,
+      int? seq,
+      Duration timeout = const Duration(seconds: 2)}) {
+    return js._purgeStream(name,
+        filter: filter, keep: keep, seq: seq, timeout: timeout);
   }
 
   /// Bind to a consumer on this stream

--- a/lib/src/object_store.dart
+++ b/lib/src/object_store.dart
@@ -9,6 +9,19 @@ import 'common.dart';
 import 'jetstream.dart';
 import 'inbox.dart';
 
+/// Captures the single [Digest] event a [Hash.startChunkedConversion] sink
+/// produces on [close], so a SHA-256 digest can be computed incrementally
+/// over a stream of chunks without buffering the whole payload in memory.
+class _DigestSink implements Sink<Digest> {
+  Digest? value;
+
+  @override
+  void add(Digest data) => value = data;
+
+  @override
+  void close() {}
+}
+
 /// Represents a link to another object or bucket in the Object Store.
 class ObjectLink {
   /// The bucket name the link points to
@@ -195,9 +208,13 @@ class ObjectStore {
   /// Create a new ObjectStore instance
   ObjectStore(this.client, this.bucket) : streamName = 'OBJ_$bucket';
 
-  /// Store an object in the bucket
+  /// Store an object in the bucket. If [name] already has an object stored
+  /// under it, the previous version's chunks are purged from the backing
+  /// stream once the new object is safely written, so overwriting an object
+  /// no longer leaves its old chunks orphaned server-side.
   Future<ObjectInfo> put(String name, Uint8List data,
       {String description = ''}) async {
+    final previous = await getInfo(name);
     final nuid = Nuid().next();
     final totalSize = data.length;
 
@@ -245,6 +262,11 @@ class ObjectStore {
     await client
         .jetStream()
         .publish(metadataSubject, Uint8List.fromList(payload));
+
+    if (previous != null && previous.chunks > 0 && previous.nuid != nuid) {
+      await _purgeChunks(previous.nuid);
+    }
+
     return info;
   }
 
@@ -252,6 +274,82 @@ class ObjectStore {
   Future<ObjectInfo> putBytes(String name, Uint8List data,
       {String description = ''}) {
     return put(name, data, description: description);
+  }
+
+  /// Store an object from a stream of byte chunks without buffering the
+  /// whole payload in memory at once -- useful for large objects. Input
+  /// chunks are re-buffered/re-sliced to [defaultChunkSize] pieces before
+  /// publishing, matching [put]'s on-wire framing, and the SHA-256 digest
+  /// is computed incrementally as data arrives rather than over one
+  /// in-memory buffer. Like [put], any previous object stored under [name]
+  /// has its old chunks purged once the new object is safely written.
+  Future<ObjectInfo> putStream(String name, Stream<List<int>> data,
+      {String description = ''}) async {
+    final previous = await getInfo(name);
+    final nuid = Nuid().next();
+    final chunkSubject = '\$O.$bucket.C.$nuid';
+
+    final digestSink = _DigestSink();
+    final hashInput = sha256.startChunkedConversion(digestSink);
+
+    var totalSize = 0;
+    var chunkCount = 0;
+    var pending = BytesBuilder(copy: false);
+
+    Future<void> flushChunk(Uint8List chunk) async {
+      await client.pub(chunkSubject, chunk);
+      chunkCount++;
+    }
+
+    await for (final piece in data) {
+      final bytes = piece is Uint8List ? piece : Uint8List.fromList(piece);
+      if (bytes.isEmpty) continue;
+      hashInput.add(bytes);
+      totalSize += bytes.length;
+      pending.add(bytes);
+      while (pending.length >= defaultChunkSize) {
+        final buffered = pending.takeBytes();
+        await flushChunk(Uint8List.sublistView(buffered, 0, defaultChunkSize));
+        pending = BytesBuilder(copy: false);
+        if (buffered.length > defaultChunkSize) {
+          pending.add(Uint8List.sublistView(buffered, defaultChunkSize));
+        }
+      }
+    }
+    if (pending.length > 0) {
+      await flushChunk(pending.takeBytes());
+    }
+    hashInput.close();
+
+    // Ensure all chunks are flushed to the server
+    await client.flush();
+
+    final digest = 'SHA-256=${base64Url.encode(digestSink.value!.bytes)}';
+
+    final info = ObjectInfo(
+      name: name,
+      description: description,
+      bucket: bucket,
+      nuid: nuid,
+      size: totalSize,
+      mtime: DateTime.now(),
+      chunks: chunkCount,
+      digest: digest,
+    );
+
+    final encodedName = base64Url.encode(utf8.encode(name));
+    final metadataSubject = '\$O.$bucket.M.$encodedName';
+    final payload = utf8.encode(jsonEncode(info.toJson()));
+
+    await client
+        .jetStream()
+        .publish(metadataSubject, Uint8List.fromList(payload));
+
+    if (previous != null && previous.chunks > 0 && previous.nuid != nuid) {
+      await _purgeChunks(previous.nuid);
+    }
+
+    return info;
   }
 
   /// Store a string payload as an object
@@ -456,6 +554,115 @@ class ObjectStore {
     return utf8.decode(bytes);
   }
 
+  /// Retrieve an object's bytes as a stream of chunks instead of buffering
+  /// the whole payload in memory -- useful for large objects. Digest
+  /// verification still happens once every chunk has arrived; a mismatch is
+  /// surfaced as an error event on the returned stream rather than a thrown
+  /// exception, since by then earlier chunks have already been handed to
+  /// the caller. Resolves object links recursively up to 5 jumps, the same
+  /// as [get].
+  Stream<Uint8List> getStream(String name, {int depth = 0}) {
+    final controller = StreamController<Uint8List>();
+
+    Future<void> run() async {
+      if (depth > 5) {
+        controller
+            .addError(NatsException('Circular link dependency detected.'));
+        await controller.close();
+        return;
+      }
+
+      final info = await getInfo(name);
+      if (info == null || info.deleted) {
+        await controller.close();
+        return;
+      }
+
+      if (info.link != null) {
+        if (info.link!.name == null) {
+          controller
+              .addError(NatsException('Cannot get data from a bucket link.'));
+          await controller.close();
+          return;
+        }
+        final targetStore = ObjectStore(client, info.link!.bucket);
+        await controller.addStream(
+            targetStore.getStream(info.link!.name!, depth: depth + 1));
+        await controller.close();
+        return;
+      }
+
+      if (info.chunks == 0) {
+        await controller.close();
+        return;
+      }
+
+      final deliverSubject = client.inboxPrefix + '.' + Nuid().next();
+      final sub = client.sub(deliverSubject);
+
+      final consumerConfig = ConsumerConfig(
+        deliverSubject: deliverSubject,
+        filterSubject: '\$O.$bucket.C.${info.nuid}',
+        deliverPolicy: 'all',
+        ackPolicy: 'none',
+      );
+
+      var received = 0;
+      final digestSink = _DigestSink();
+      final hashInput = sha256.startChunkedConversion(digestSink);
+      final done = Completer<void>();
+      StreamSubscription? sourceSub;
+      Timer? timeoutTimer;
+
+      void cleanup() {
+        timeoutTimer?.cancel();
+        sourceSub?.cancel();
+        client.unSub(sub);
+      }
+
+      timeoutTimer = Timer(const Duration(seconds: 15), () {
+        cleanup();
+        controller
+            .addError(NatsException('Timed out retrieving object chunks.'));
+        if (!done.isCompleted) done.complete();
+      });
+
+      sourceSub = sub.stream.listen((msg) {
+        hashInput.add(msg.byte);
+        controller.add(msg.byte);
+        received++;
+        if (received >= info.chunks) {
+          cleanup();
+          hashInput.close();
+          final digest = 'SHA-256=${base64Url.encode(digestSink.value!.bytes)}';
+          if (digest != info.digest) {
+            controller
+                .addError(NatsException('SHA-256 digest verification failed.'));
+          }
+          if (!done.isCompleted) done.complete();
+        }
+      }, onError: (err) {
+        cleanup();
+        controller.addError(err);
+        if (!done.isCompleted) done.complete();
+      });
+
+      try {
+        await client.jetStream().createConsumer('OBJ_$bucket', consumerConfig);
+      } catch (e) {
+        cleanup();
+        controller.addError(e);
+        if (!done.isCompleted) done.complete();
+      }
+
+      await done.future;
+      await controller.close();
+    }
+
+    run();
+    return controller.stream;
+  }
+
   /// Delete/mark object deleted and purge its chunk history
   Future<bool> delete(String name) async {
     final info = await getInfo(name);
@@ -483,13 +690,25 @@ class ObjectStore {
         .publish(metadataSubject, Uint8List.fromList(payload));
 
     // Purge the chunks subject to reclaim NATS space
-    final purgeSubject = '\$JS.API.STREAM.PURGE.OBJ_$bucket';
-    final purgePayload = utf8.encode(jsonEncode({
-      'filter': '\$O.$bucket.C.${info.nuid}',
-    }));
-    await client.request(purgeSubject, Uint8List.fromList(purgePayload));
+    if (info.chunks > 0) {
+      await _purgeChunks(info.nuid);
+    }
 
     return true;
+  }
+
+  /// Purge a stored object's chunks (identified by its `nuid`) from the
+  /// backing stream. Used both by [delete] and by [put]/[putStream] when
+  /// overwriting an object, so a previous version's chunks don't linger
+  /// server-side once nothing references them anymore.
+  Future<void> _purgeChunks(String nuid,
+      {Duration timeout = const Duration(seconds: 2)}) async {
+    final purgeSubject = '\$JS.API.STREAM.PURGE.OBJ_$bucket';
+    final purgePayload = utf8.encode(jsonEncode({
+      'filter': '\$O.$bucket.C.$nuid',
+    }));
+    await client.request(purgeSubject, Uint8List.fromList(purgePayload),
+        timeout: timeout);
   }
 
   /// List all active objects in this Object Store bucket

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_nats
 description: A Dart client for the NATS messaging system. Design to use with Dart and flutter.
-version: 1.3.0
+version: 1.4.0
 homepage: https://github.com/dart-nats
 repository: https://github.com/dart-nats/dart-nats
 

--- a/test/jetstream_test.dart
+++ b/test/jetstream_test.dart
@@ -94,6 +94,50 @@ void main() {
       expect(deleteResult, isTrue);
     });
 
+    test('Stream Purge with filter/keep/seq options', () async {
+      final streamName = 'purge-opts-test';
+      final subjectA = 'purge.opts.a';
+      final subjectB = 'purge.opts.b';
+
+      final stream = await js.createStream(StreamConfig(
+        name: streamName,
+        subjects: ['purge.opts.*'],
+        storage: 'memory',
+      ));
+
+      // 1. filter: purge only messages on a matching subject
+      await js.publishString(subjectA, 'a1');
+      await js.publishString(subjectA, 'a2');
+      await js.publishString(subjectB, 'b1');
+
+      await stream.purge(filter: subjectA);
+      var info = await stream.info();
+      expect(info.state.messages, equals(1));
+      expect((await js.getLastMsg(streamName, subjectB)).string, equals('b1'));
+
+      // 2. keep: retain only the newest N messages overall
+      await js.publishString(subjectB, 'b2');
+      await js.publishString(subjectB, 'b3');
+      info = await stream.info();
+      expect(info.state.messages, equals(3));
+
+      await stream.purge(keep: 1);
+      info = await stream.info();
+      expect(info.state.messages, equals(1));
+      expect((await js.getLastMsg(streamName, subjectB)).string, equals('b3'));
+
+      // 3. seq: purge everything up to but not including a sequence number
+      await js.publishString(subjectB, 'b4');
+      final ack5 = await js.publishString(subjectB, 'b5');
+
+      await stream.purge(seq: ack5.sequence);
+      info = await stream.info();
+      expect(info.state.messages, equals(1));
+      expect((await js.getLastMsg(streamName, subjectB)).string, equals('b5'));
+
+      await js.deleteStream(streamName);
+    });
+
     test('Publishing and Message Get APIs', () async {
       final streamName = 'pub-get-test';
       final subject = 'pub.get.subj';

--- a/test/object_store_test.dart
+++ b/test/object_store_test.dart
@@ -206,6 +206,129 @@ void main() {
       );
     });
 
+    test('Object Store overwrite purges the previous version\'s chunks',
+        () async {
+      final os = await js.createObjectStore(
+        ObjectStoreConfig(bucket: bucket, storage: 'memory'),
+      );
+
+      final size = 150 * 1024; // 150 KiB -> 2 chunks
+      final originalData = Uint8List(size);
+      for (var i = 0; i < size; i++) {
+        originalData[i] = i % 256;
+      }
+
+      final oldInfo = await os.putBytes('overwrite-me.bin', originalData);
+      expect(oldInfo.chunks, equals(2));
+      final oldChunkSubject = '\$O.$bucket.C.${oldInfo.nuid}';
+      expect(
+          await _chunkSubjectHasMessages(
+              client, 'OBJ_$bucket', oldChunkSubject),
+          isTrue);
+
+      final newData = Uint8List.fromList(utf8.encode('replacement payload'));
+      final newInfo = await os.putBytes('overwrite-me.bin', newData);
+      expect(newInfo.nuid, isNot(equals(oldInfo.nuid)));
+
+      // The old version's chunks should be gone from the backing stream.
+      expect(
+          await _chunkSubjectHasMessages(
+              client, 'OBJ_$bucket', oldChunkSubject),
+          isFalse);
+
+      // The new version is still readable and correct.
+      final readBack = await os.getBytes('overwrite-me.bin');
+      expect(readBack, equals(newData));
+    });
+
+    test('Object Store streaming put/get (putStream/getStream)', () async {
+      final os = await js.createObjectStore(
+        ObjectStoreConfig(bucket: bucket, storage: 'memory'),
+      );
+
+      final size = 300 * 1024; // 300 KiB -> 3 chunks of up to 128 KiB
+      final originalData = Uint8List(size);
+      for (var i = 0; i < size; i++) {
+        originalData[i] = (i * 7) % 256;
+      }
+
+      // Feed putStream with small, uneven pieces to exercise re-chunking.
+      Stream<List<int>> unevenChunks() async* {
+        const pieceSize = 4096;
+        var offset = 0;
+        while (offset < originalData.length) {
+          final end = (offset + pieceSize > originalData.length)
+              ? originalData.length
+              : offset + pieceSize;
+          yield originalData.sublist(offset, end);
+          offset = end;
+        }
+      }
+
+      final info = await os.putStream('streamed.bin', unevenChunks());
+      expect(info.size, equals(size));
+      expect(info.chunks, equals(3));
+
+      final received = <int>[];
+      await for (final chunk in os.getStream('streamed.bin')) {
+        received.addAll(chunk);
+      }
+      expect(Uint8List.fromList(received), equals(originalData));
+
+      // The buffered get() path should read back the same data too.
+      final bytes = await os.getBytes('streamed.bin');
+      expect(bytes, equals(originalData));
+
+      // Overwriting a streamed-put object via putStream also purges the
+      // previous version's chunks.
+      final oldChunkSubject = '\$O.$bucket.C.${info.nuid}';
+      expect(
+          await _chunkSubjectHasMessages(
+              client, 'OBJ_$bucket', oldChunkSubject),
+          isTrue);
+
+      Stream<List<int>> replacement() async* {
+        yield utf8.encode('short replacement');
+      }
+
+      final newInfo = await os.putStream('streamed.bin', replacement());
+      expect(newInfo.nuid, isNot(equals(info.nuid)));
+      expect(
+          await _chunkSubjectHasMessages(
+              client, 'OBJ_$bucket', oldChunkSubject),
+          isFalse);
+      expect(await os.getString('streamed.bin'), equals('short replacement'));
+    });
+
+    test('Object Store getStream surfaces digest verification failure',
+        () async {
+      final store = await js.createObjectStore(
+        ObjectStoreConfig(bucket: bucket, storage: 'memory'),
+      );
+
+      final info =
+          await store.putString('corrupt-stream.txt', 'integrity test');
+
+      final purgeSubject = '\$JS.API.STREAM.PURGE.OBJ_$bucket';
+      final purgePayload = utf8.encode(jsonEncode({
+        'filter': '\$O.$bucket.C.${info.nuid}',
+      }));
+      await client.request(purgeSubject, Uint8List.fromList(purgePayload));
+
+      final chunkSubject = '\$O.$bucket.C.${info.nuid}';
+      await client.pubString(chunkSubject, 'corrupted chunk');
+      await client.flush();
+
+      expect(
+        () => store.getStream('corrupt-stream.txt').drain<void>(),
+        throwsA(isA<NatsException>().having(
+          (e) => e.message,
+          'message',
+          contains('SHA-256 digest verification failed'),
+        )),
+      );
+    });
+
     test('Object Store integrity digest validation failure', () async {
       final store = await js.createObjectStore(
         ObjectStoreConfig(bucket: bucket, storage: 'memory'),
@@ -237,4 +360,18 @@ void main() {
       );
     });
   });
+}
+
+/// Whether a direct-get last-by-subject request against [subject] on
+/// [streamName] finds any message -- used to confirm a purged chunk subject
+/// genuinely has nothing left, the same technique [ObjectStore.getInfo]
+/// itself uses to look up metadata.
+Future<bool> _chunkSubjectHasMessages(
+    Client client, String streamName, String subject) async {
+  final apiSubject = '\$JS.API.STREAM.MSG.GET.$streamName';
+  final payload = utf8.encode(jsonEncode({'last_by_subj': subject}));
+  final response =
+      await client.request(apiSubject, Uint8List.fromList(payload));
+  final map = jsonDecode(response.string);
+  return map['error'] == null;
 }


### PR DESCRIPTION
## Summary
- Add filter/keep/seq options to JetStream stream purge (ROADMAP M30)
- Add ObjectStore.putStream()/getStream() for large objects without full in-memory buffering (ROADMAP M30)
- Fix ObjectStore put()/putStream() leaving previous chunks orphaned on overwrite (ROADMAP M30)
- Bump actions/checkout and actions/cache to fix Node 20 deprecation warnings
- Bump to 1.4.0

## Test plan
- [x] Full `dart test -j 1` suite passes locally (173/173) against docker-compose NATS containers
- [x] `dart analyze` / `dart format --set-exit-if-changed` clean
- [x] `dart pub publish --dry-run` clean (0 warnings)
- [ ] CI green on this PR